### PR TITLE
CNV-40006: MAC spoof checkbox is not affecting the NAD config

### DIFF
--- a/src/views/nads/form/components/NetworkTypeParameters/components/BridgeParameters/BridgeParameters.tsx
+++ b/src/views/nads/form/components/NetworkTypeParameters/components/BridgeParameters/BridgeParameters.tsx
@@ -25,12 +25,14 @@ const BridgeParameters: FC<ParametersComponentProps> = ({ control, register }) =
       </FormGroup>
       <Controller
         control={control}
+        defaultValue={true as never}
         name={`${NetworkTypeKeys.cnvBridgeNetworkType}.macspoofchk`}
-        render={() => (
+        render={({ field: { onChange, value } }) => (
           <Checkbox
-            defaultChecked
             id={`${NetworkTypeKeys.cnvBridgeNetworkType}.macspoofchk`}
+            isChecked={value}
             label={t('MAC spoof check')}
+            onChange={onChange}
           />
         )}
       />


### PR DESCRIPTION
The controller was not connected to the Checkbox component hence the form data was missing the `macspoofchk` property