### PR TITLE
CONSOLE-3992: Fix nginx not available on rhel 9

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -26,10 +26,8 @@ RUN test -d ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps || exit 1; \
 # Web server container
 FROM registry.ci.openshift.org/ocp/4.16:base
 
-ENV NGINX_VERSION=1.20
-RUN yum -y module enable nginx:$NGINX_VERSION && \
-    INSTALL_PKGS="nginx" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+RUN INSTALL_PKGS="nginx" && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*' && \
     chown -R 1001:0 /var/lib/nginx /var/log/nginx /run && \


### PR DESCRIPTION
nginx is not available on rhel 9 so fixing it just like https://github.com/openshift/monitoring-plugin/pull/110/files