### PR TITLE
CNV-40092: UI should use type "bridge" instead of "cnv-bridge"

### DIFF
--- a/src/views/nads/form/utils/types.ts
+++ b/src/views/nads/form/utils/types.ts
@@ -1,5 +1,5 @@
 export enum NetworkTypeKeys {
-  cnvBridgeNetworkType = 'cnv-bridge',
+  cnvBridgeNetworkType = 'bridge',
   ovnKubernetesNetworkType = 'ovn-k8s-cni-overlay',
   ovnKubernetesSecondaryLocalnet = 'ovn-k8s-cni-overlay-localnet',
   sriovNetworkType = 'sriov',
@@ -12,7 +12,7 @@ export type NetworkTypeKeysType =
   | NetworkTypeKeys.sriovNetworkType;
 
 export const networkTypes: Record<NetworkTypeKeysType, string> = {
-  [NetworkTypeKeys.cnvBridgeNetworkType]: 'CNV Linux bridge',
+  [NetworkTypeKeys.cnvBridgeNetworkType]: 'Linux bridge',
   [NetworkTypeKeys.ovnKubernetesNetworkType]: 'OVN Kubernetes L2 overlay network',
   [NetworkTypeKeys.ovnKubernetesSecondaryLocalnet]: 'OVN Kubernetes secondary localnet network',
   [NetworkTypeKeys.sriovNetworkType]: 'SR-IOV',


### PR DESCRIPTION
Changing to use type `bridge` instead of `cnv-bridge` on NAD create form

Before:
![cnv-bridge-type2](https://github.com/openshift/networking-console-plugin/assets/67270715/04586f87-d94c-4794-976d-1cb62902a40e)

![cnv-bridge-type](https://github.com/openshift/networking-console-plugin/assets/67270715/d0c3b7f8-5db1-41b1-95c4-9a5c5826c306)

After:
![bridge-type2](https://github.com/openshift/networking-console-plugin/assets/67270715/37677608-a3da-4ae1-850f-9858cfa67cb1)

![bridge-type](https://github.com/openshift/networking-console-plugin/assets/67270715/426ed59a-da03-42e2-a889-f20e83fa8658)
