### PR TITLE
Show error message for failed submit

### DIFF
--- a/src/views/nads/form/NetworkAttachmentDefinitionForm.tsx
+++ b/src/views/nads/form/NetworkAttachmentDefinitionForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
@@ -32,15 +32,15 @@ import { createNetAttachDef } from './utils/utils';
 const NetworkAttachmentDefinitionForm: FC = () => {
   const { t } = useNetworkingTranslation();
   const navigate = useNavigate();
+  const [apiError, setError] = useState<Error>(null);
   const [activeNamespace] = useActiveNamespace();
   const namespace = ALL_NAMESPACES_KEY === activeNamespace ? DEFAULT_NAMESPACE : activeNamespace;
 
   const {
     control,
-    formState: { errors, isSubmitting, isValid },
+    formState: { isSubmitting, isValid },
     handleSubmit,
     register,
-    setError,
     watch,
   } = useForm<NetworkAttachmentDefinitionFormInput>({
     defaultValues: {
@@ -56,7 +56,7 @@ const NetworkAttachmentDefinitionForm: FC = () => {
         navigate(resourcePathFromModel(NetworkAttachmentDefinitionModel, data?.name, namespace));
       })
       .catch((err) => {
-        setError('root', err);
+        setError(err);
       });
   };
 
@@ -84,9 +84,9 @@ const NetworkAttachmentDefinitionForm: FC = () => {
           </FormGroup>
           <NetworkAttachmentDefinitionTypeSelect control={control} />
           <NetworkTypeParameters control={control} networkType={networkType} register={register} />
-          {!isEmpty(errors?.root) && (
+          {!isEmpty(apiError) && (
             <Alert isInline title={t('Error')} variant={AlertVariant.danger}>
-              {errors?.root?.message}
+              {apiError?.message}
             </Alert>
           )}
           <ActionGroup>


### PR DESCRIPTION
Using a state to catch the error message, as react-hook-form error objects may change on different errors and no way to know which field to access to get the proper error message

Before:
![show-backend-error-message-b4](https://github.com/openshift/networking-console-plugin/assets/67270715/5848bcfc-17a8-4aa1-aaad-de10766d10aa)

After:
![show-backend-error-message](https://github.com/openshift/networking-console-plugin/assets/67270715/24035bbd-162f-43e0-9eca-19761b25aaad)
