### PR TITLE
CNV-39286: Fix NetworkPolicy SyncedEditor

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.15.5",
     "@kubevirt-ui/kubevirt-api": "^1.2.2",
-    "@openshift-console/dynamic-plugin-sdk": "1.1.0",
+    "@openshift-console/dynamic-plugin-sdk": "1.3.0",
     "@openshift-console/dynamic-plugin-sdk-internal": "1.0.0",
     "@openshift-console/dynamic-plugin-sdk-webpack": "1.0.1",
     "@openshift-console/plugin-shared": "^0.0.1",

--- a/src/utils/models/network-policy.ts
+++ b/src/utils/models/network-policy.ts
@@ -462,7 +462,7 @@ export const networkPolicyFromK8sResource = (
   }
 
   const policyFor =
-    from?.metadata?.annotations?.[POLICY_FOR_LABEL]?.split(',').map((nad) => nad.trim()) || [];
+    from?.metadata?.annotations?.[POLICY_FOR_LABEL]?.split(',').map((nad) => nad.trim()) || null;
 
   return {
     egress: egressRules,

--- a/src/views/networkpolicies/list/components/NetworkPolicyEmptyState.tsx
+++ b/src/views/networkpolicies/list/components/NetworkPolicyEmptyState.tsx
@@ -35,7 +35,7 @@ const NetworkPolicyEmptyState: FC = () => {
         <EmptyStateActions>
           <Button
             onClick={() =>
-              navigate(`/k8s/ns/${lastNamespacePath}/${modelToRef(networkModel)}/~new/form`)
+              navigate(`/k8s/${lastNamespacePath}/${modelToRef(networkModel)}/~new/form`)
             }
           >
             {t('Create {{kind}}', { kind: networkModel.kind })}

--- a/src/views/networkpolicies/new/NetworkPolicyConditionalSelector.tsx
+++ b/src/views/networkpolicies/new/NetworkPolicyConditionalSelector.tsx
@@ -42,7 +42,7 @@ const NetworkPolicyConditionalSelector: FC<NetworkPolicyConditionalSelectorProps
         <label>{title}</label>
       </span>
       <Text component="p">{helpText}</Text>
-      {isVisible ? (
+      {isVisible || !isEmpty(values) ? (
         <>
           <Text component="p">{secondHelpText}</Text>
           <LabelSelectorEditor

--- a/src/views/networkpolicies/new/NetworkPolicyForm.tsx
+++ b/src/views/networkpolicies/new/NetworkPolicyForm.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 
 import { NetworkPolicyModel } from '@kubevirt-ui/kubevirt-api/console';
-import { CodeEditor } from '@openshift-console/dynamic-plugin-sdk';
+import { ResourceYAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
 import {
   PageSection,
   PageSectionVariants,
@@ -12,6 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { EditorType } from '@utils/components/SyncedEditor/EditorToggle';
 import { SyncedEditor } from '@utils/components/SyncedEditor/SyncedEditor';
+import { safeYAMLToJS } from '@utils/components/SyncedEditor/yaml';
 import { MultiNetworkPolicyModel, networkPolicyToK8sResource } from '@utils/models';
 
 import useIsMultiNetworkPolicy from './hooks/useIsMultiNetworkPolicy';
@@ -44,7 +45,12 @@ const NetworkPolicyForm: FC = () => {
           setHelpText(type === EditorType.Form ? FORM_HELPER_TEXT : YAM_HELPER_TEXT)
         }
         YAMLEditor={({ initialYAML = '', onChange }) => (
-          <CodeEditor onChange={onChange} value={initialYAML} />
+          <ResourceYAMLEditor
+            create
+            hideHeader
+            initialResource={safeYAMLToJS(initialYAML)}
+            onChange={onChange}
+          />
         )}
       />
     </>

--- a/src/views/networkpolicies/new/components/NetworkPolicyFormEgress.tsx
+++ b/src/views/networkpolicies/new/components/NetworkPolicyFormEgress.tsx
@@ -28,7 +28,7 @@ const NetworkPolicyFormEgress: FC<NetworkPolicyFormEgressProps> = ({
   const { t } = useNetworkingTranslation();
 
   if (
-    !networkPolicy.egress.denyAll &&
+    networkPolicy.egress.denyAll &&
     networkFeaturesLoaded &&
     networkFeatures.PolicyEgress !== false
   )

--- a/src/views/networkpolicies/new/components/NetworkPolicyFormIngress.tsx
+++ b/src/views/networkpolicies/new/components/NetworkPolicyFormIngress.tsx
@@ -22,7 +22,7 @@ const NetworkPolicyFormIngress: FC<NetworkPolicyFormIngressProps> = ({
 }) => {
   const { t } = useNetworkingTranslation();
 
-  if (!networkPolicy.ingress.denyAll) return null;
+  if (networkPolicy.ingress.denyAll) return null;
 
   const updateIngressRules = (rules: NetworkPolicyRule[]) =>
     onPolicyChange({

--- a/yarn.lock
+++ b/yarn.lock
@@ -297,10 +297,10 @@
     semver "6.x"
     webpack "5.75.0"
 
-"@openshift-console/dynamic-plugin-sdk@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-1.1.0.tgz#63b525aba54f01231921af23939cae0059e02eaf"
-  integrity sha512-gaNqhGq7nne+cC3QaCxuyK+SPvuC/K5Ww5tV2FabIepgbl3qKkUePrejPgvBJ52tMID1sn8prdW/rImYma6NwQ==
+"@openshift-console/dynamic-plugin-sdk@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@openshift-console/dynamic-plugin-sdk/-/dynamic-plugin-sdk-1.3.0.tgz#70d48743e56c5f8887b173087a5804411b5c9510"
+  integrity sha512-TTclIiLrgV+d/GLXmMBpRf6lt9qQ2a9Ur53RtRYp0HGDT4fystMto/xEwSM5b2B17rL03LxATvmK96GIk1BWXQ==
   dependencies:
     classnames "2.x"
     immutable "3.x"


### PR DESCRIPTION
The SyncedEditor was not working properly. It had no sidebar. Here the sidebar is important as it shows samples and schema info for the creation. 
Other than that, I had to change something in the form to make the sync work. This means that when you change something in the yaml editor, you can see the change if you switch to form 

![Screenshot from 2024-04-10 15-48-57](https://github.com/openshift/networking-console-plugin/assets/29160323/c720e422-e0eb-4b85-a424-18a150a83d53)
![Screenshot from 2024-04-10 15-48-49](https://github.com/openshift/networking-console-plugin/assets/29160323/af432423-6bd9-4b3f-9751-f963955ac407)
![Screenshot from 2024-04-10 15-48-46](https://github.com/openshift/networking-console-plugin/assets/29160323/bbbc83fc-c77d-4833-86c6-4dccc3cc0f4e)
