### PR TITLE
fix create button from /~new to /~new/form to show the creation form

### DIFF
--- a/src/views/routes/list/RoutesList.tsx
+++ b/src/views/routes/list/RoutesList.tsx
@@ -13,10 +13,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import ListEmptyState from '@utils/components/ListEmptyState/ListEmptyState';
 import { DEFAULT_NAMESPACE } from '@utils/constants';
-import {
-  SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM,
-  SHARED_DEFAULT_PATH_NEW_RESOURCE_YAML,
-} from '@utils/constants/ui';
+import { SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM } from '@utils/constants/ui';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { resourcePathFromModel } from '@utils/resources/shared';
 import { RouteKind } from '@utils/types';
@@ -42,7 +39,7 @@ const RoutesList: FC<RoutesListProps> = ({ namespace }) => {
 
   return (
     <ListEmptyState<RouteKind>
-      createButtonlink={SHARED_DEFAULT_PATH_NEW_RESOURCE_YAML}
+      createButtonlink={SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}
       data={routes}
       kind={RouteModel.kind}
       learnMoreLink="https://docs.openshift.com/dedicated/networking/routes/route-configuration.html"


### PR DESCRIPTION

Show the form instead of yaml creation on empty list create button 

<img width="1920" alt="Screenshot 2024-08-27 at 16 20 44" src="https://github.com/user-attachments/assets/b59cda0e-0078-4708-81da-49be8a8a6306">
