### PR TITLE
Use rhel9 base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,14 @@ USER 0
 RUN yarn install --frozen-lockfile --network-timeout 600000 && yarn build
 
 # Web server container
-FROM registry.access.redhat.com/ubi9/nginx-120
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+
+RUN INSTALL_PKGS="nginx" && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*' && \
+    chown -R 1001:0 /var/lib/nginx /var/log/nginx /run && \
+    chmod -R ug+rwX /var/lib/nginx /var/log/nginx /run
 
 # Use none-root user
 USER 1001


### PR DESCRIPTION
Recently, we added OKD configs for openshift components. The config overrides the base image with a centos image, which doesn't work because the base image for the Dockerfile is an nginx image. To be consistent with other repos and the ART dockerfile, change the nginx base image to a rhel base image, so that prow cando the substitution. This also prevents any CVE vulnerabilities we would have when using the nginx image.