### PR TITLE
OCPBUGS-39083: fix switching namespaces in policies

### DIFF
--- a/src/views/networkpolicies/list/NetworkPolicyPage.tsx
+++ b/src/views/networkpolicies/list/NetworkPolicyPage.tsx
@@ -1,18 +1,16 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
-import { modelToRef, NetworkPolicyModel } from '@kubevirt-ui/kubevirt-api/console';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
-import { useLastNamespacePath } from '@utils/hooks/useLastNamespacePath';
+import { ALL_NAMESPACES } from '@utils/constants';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
-import { MultiNetworkPolicyModel } from '@utils/models';
 
 import useIsMultiEnabled from './hooks/useIsMultiEnabled';
 import { TAB_INDEXES } from './constants';
 import EnableMultiPage from './EnableMultiPage';
 import MultiNetworkPolicyList from './MultiNetworkPolicyList';
 import NetworkPolicyList from './NetworkPolicyList';
-import { getActiveKeyFromPathname } from './utils';
+import { getActiveKeyFromPathname, getNetworkPolicyURLTab } from './utils';
 
 export type NetworkPolicyPageNavProps = {
   namespace: string;
@@ -21,31 +19,20 @@ export type NetworkPolicyPageNavProps = {
 const NetworkPolicyDetailsPage: FC<NetworkPolicyPageNavProps> = ({ namespace }) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const lastNamespacePath = useLastNamespacePath();
-  const [activeTabKey, setActiveTabKey] = useState<number | string>(
-    getActiveKeyFromPathname(location?.pathname),
+
+  const locationTabKey = useMemo(
+    () => getActiveKeyFromPathname(location?.pathname),
+    [location?.pathname],
   );
 
   const [isMultiEnabled] = useIsMultiEnabled();
-
-  useEffect(() => {
-    if (activeTabKey === TAB_INDEXES.ENABLE_MULTI) {
-      navigate(`/k8s/${lastNamespacePath}/${modelToRef(NetworkPolicyModel)}/enable-multi`);
-      return;
-    }
-
-    navigate(
-      `/k8s/${lastNamespacePath}/${activeTabKey === TAB_INDEXES.NETWORK ? modelToRef(NetworkPolicyModel) : modelToRef(MultiNetworkPolicyModel)}`,
-    );
-  }, [activeTabKey, lastNamespacePath, location.pathname, navigate]);
-
   const { t } = useNetworkingTranslation();
 
   return (
     <Tabs
-      activeKey={activeTabKey}
+      activeKey={locationTabKey}
       onSelect={(_, tabIndex: number | string) => {
-        setActiveTabKey(tabIndex);
+        navigate(getNetworkPolicyURLTab(tabIndex, namespace || ALL_NAMESPACES));
       }}
     >
       <Tab

--- a/src/views/networkpolicies/list/utils.ts
+++ b/src/views/networkpolicies/list/utils.ts
@@ -1,3 +1,5 @@
+import { modelToRef, NetworkPolicyModel } from '@kubevirt-ui/kubevirt-api/console';
+import { ALL_NAMESPACES } from '@utils/constants';
 import { MultiNetworkPolicyModel } from '@utils/models';
 
 import { TAB_INDEXES } from './constants';
@@ -8,4 +10,14 @@ export const getActiveKeyFromPathname = (pathname: string) => {
   if (pathname.includes('enable-multi')) return TAB_INDEXES.ENABLE_MULTI;
 
   return TAB_INDEXES.NETWORK;
+};
+
+export const getNetworkPolicyURLTab = (tabIndex: number | string, namespace: string): string => {
+  const namespacePath = namespace === ALL_NAMESPACES ? namespace : `ns/${namespace}`;
+
+  if (tabIndex === TAB_INDEXES.ENABLE_MULTI) {
+    return `/k8s/${namespacePath}/${modelToRef(NetworkPolicyModel)}/enable-multi`;
+  }
+
+  return `/k8s/${namespacePath}/${tabIndex === TAB_INDEXES.NETWORK ? modelToRef(NetworkPolicyModel) : modelToRef(MultiNetworkPolicyModel)}`;
 };


### PR DESCRIPTION
Remove the `useEffect` and set the `activeTabKey` in the Tab `onSelect` .

The `useEffect` was there to change the `activeTabKey` on navigation change but we can even extract that from the location pathname at every render. 


**Before**


https://github.com/user-attachments/assets/4cbb2f62-2883-4127-b983-d9c480e2f095



**After**


https://github.com/user-attachments/assets/289728eb-ae29-4c9b-8b85-cae7f57c1412

