### PR TITLE
OCPBUGS-39248:  fix pod selector path

### DIFF
--- a/src/utils/components/PodSelectorModal/PodSelectorModal.tsx
+++ b/src/utils/components/PodSelectorModal/PodSelectorModal.tsx
@@ -36,7 +36,7 @@ export type PodSelectorModalProps = {
 const PodSelectorModal: FC<PodSelectorModalProps> = ({
   closeModal,
   model,
-  path = '/spec/selector',
+  path = 'spec.selector',
   resource,
 }) => {
   const { t } = useNetworkingTranslation();


### PR DESCRIPTION
don't use `/spec/selector/` but `spec.selector`