### PR TITLE
OCPBUGS-39250: fix small routes bugs

### DIFF
--- a/src/utils/resources/shared.ts
+++ b/src/utils/resources/shared.ts
@@ -130,7 +130,7 @@ export const resourcePathFromModel = (
   name?: string,
   namespace = DEFAULT_NAMESPACE,
 ) => {
-  const { crd, namespaced, plural } = model;
+  const { namespaced } = model;
 
   let url = '/k8s/';
 
@@ -142,11 +142,7 @@ export const resourcePathFromModel = (
     url += namespace ? `ns/${namespace}/` : 'all-namespaces/';
   }
 
-  if (crd) {
-    url += `${model.apiGroup}~${model.apiVersion}~${model.kind}`;
-  } else if (plural) {
-    url += plural;
-  }
+  url += `${model.apiGroup}~${model.apiVersion}~${model.kind}`;
 
   if (name) {
     // Some resources have a name that needs to be encoded. For instance,

--- a/src/views/routes/form/RouteForm.tsx
+++ b/src/views/routes/form/RouteForm.tsx
@@ -78,8 +78,8 @@ const RouteForm: FC<RouteFormProps> = ({ formData, onChange: onFormChange }) => 
               </HelperText>
             </FormHelperText>
           </FormGroup>
-          <FormGroup fieldId={HOST_FIELD_ID} isRequired label={t('Hostname')}>
-            <TextInput id={HOST_FIELD_ID} {...register('spec.host', { required: true })} />
+          <FormGroup fieldId={HOST_FIELD_ID} label={t('Hostname')}>
+            <TextInput id={HOST_FIELD_ID} {...register('spec.host', { required: false })} />
             <FormHelperText>
               <HelperText>
                 <HelperTextItem>
@@ -88,8 +88,8 @@ const RouteForm: FC<RouteFormProps> = ({ formData, onChange: onFormChange }) => 
               </HelperText>
             </FormHelperText>
           </FormGroup>
-          <FormGroup fieldId={PATH_FIELD_ID} isRequired label={t('Path')}>
-            <TextInput id={PATH_FIELD_ID} {...register('spec.path', { required: true })} />
+          <FormGroup fieldId={PATH_FIELD_ID} label={t('Path')}>
+            <TextInput id={PATH_FIELD_ID} {...register('spec.path', { required: false })} />
             <FormHelperText>
               <HelperText>
                 <HelperTextItem>


### PR DESCRIPTION


- Route create link was like `/k8s/ns/:ns/routes` instead of `/k8s/ns/:ns/route.openshift.io~v1~Route` 

- host and path are not required the route form 

The bug reported that some routes gets re-created but seems to be depending on something else. But the plugin. Maybe they are part of some deployments