### PR TITLE
CNV-47530: fix typehead select on multi policy

### DIFF
--- a/src/utils/components/SelectMultiTypeahead/Toggle.tsx
+++ b/src/utils/components/SelectMultiTypeahead/Toggle.tsx
@@ -124,7 +124,7 @@ const Toggle: FC<ToggleProps> = ({
           onChange={onTextInputChange}
           onClick={onToggleClick}
           onKeyDown={onInputKeyDown}
-          placeholder={placeholder}
+          placeholder={isEmpty(selected) ? placeholder : null}
           role="combobox"
           value={inputValue}
         >


### PR DESCRIPTION
Typeahead empty when the user select at least one item

<img width="1920" alt="Screenshot 2024-09-06 at 11 15 20" src="https://github.com/user-attachments/assets/1250f096-d7b7-4181-a807-69914631d91d">
