### PR TITLE
OCPBUGS-41618: switch key with label

### DIFF
--- a/src/utils/components/DetailsItem/LabelList.tsx
+++ b/src/utils/components/DetailsItem/LabelList.tsx
@@ -46,7 +46,7 @@ type LabelListProps = {
 export const LabelList: FC<LabelListProps> = ({ expand = true, groupVersionKind, labels }) => {
   const { t } = useNetworkingTranslation();
 
-  const list = Object.entries(labels || []).map(([label, key]) => (
+  const list = Object.entries(labels || []).map(([key, label]) => (
     <Label expand={expand} groupVersionKind={groupVersionKind} key={key} name={key} value={label} />
   ));
 


### PR DESCRIPTION
**Before**
<img width="811" alt="Screenshot 2024-09-10 at 14 30 49" src="https://github.com/user-attachments/assets/3eb88a5d-4fb2-4d99-8b30-30be0d378e07">


**After**

<img width="820" alt="Screenshot 2024-09-10 at 14 30 16" src="https://github.com/user-attachments/assets/fd19959d-0bf8-4083-bbd8-14928829e71c">
