### PR TITLE
OCPBUGS-39084: normal user have to use projects no namespaces

### DIFF
--- a/src/views/networkpolicies/new/components/NetworkPolicySelectorPreview/components/hooks/useNetworkPolicyPodPreviewData.ts
+++ b/src/views/networkpolicies/new/components/NetworkPolicySelectorPreview/components/hooks/useNetworkPolicyPodPreviewData.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { NamespaceModel, PodModel } from '@kubevirt-ui/kubevirt-api/console';
+import { PodModel, ProjectModel } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1Pod } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import {
   K8sResourceCommon,
@@ -54,7 +54,7 @@ const useNetworkPolicyPodPreviewData: UseNetworkPolicyPodPreviewData = ({
 
   const [namespaces, loadedNamespaces, namespacesError] = useK8sWatchResource<K8sResourceCommon[]>({
     isList: true,
-    kind: NamespaceModel.kind,
+    kind: ProjectModel.kind,
     selector: safeNsSelector,
   });
 


### PR DESCRIPTION
**Before**

<img width="489" alt="Screenshot 2024-09-10 at 14 32 51" src="https://github.com/user-attachments/assets/d1108323-a897-4b37-881b-4a715614249d">


**After**

<img width="490" alt="Screenshot 2024-09-10 at 14 36 03" src="https://github.com/user-attachments/assets/05b1cc3d-6870-4d41-8665-0e391d60d6ea">
