### PR TITLE
CNV-48188: Fix networkpolicy list

### DIFF
--- a/src/views/networkpolicies/list/MultiNetworkPolicyList.tsx
+++ b/src/views/networkpolicies/list/MultiNetworkPolicyList.tsx
@@ -95,6 +95,7 @@ const MultiNetworkPolicyList: FC<MultiNetworkPolicyListProps> = ({ namespace }) 
               type: '',
             }}
             data={data}
+            hideLabelFilter
             loaded={loaded}
             onFilterChange={(...args) => {
               onFilterChange(...args);

--- a/src/views/networkpolicies/list/NetworkPolicyList.tsx
+++ b/src/views/networkpolicies/list/NetworkPolicyList.tsx
@@ -94,6 +94,7 @@ const NetworkPolicyList: FC<NetworkPolicyListProps> = ({ namespace }) => {
               type: '',
             }}
             data={data}
+            hideLabelFilter
             loaded={loaded}
             onFilterChange={(...args) => {
               onFilterChange(...args);

--- a/src/views/networkpolicies/list/NetworkPolicyPage.tsx
+++ b/src/views/networkpolicies/list/NetworkPolicyPage.tsx
@@ -16,7 +16,7 @@ export type NetworkPolicyPageNavProps = {
   namespace: string;
 };
 
-const NetworkPolicyDetailsPage: FC<NetworkPolicyPageNavProps> = ({ namespace }) => {
+const NetworkPolicyPage: FC<NetworkPolicyPageNavProps> = ({ namespace }) => {
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -24,7 +24,6 @@ const NetworkPolicyDetailsPage: FC<NetworkPolicyPageNavProps> = ({ namespace }) 
     () => getActiveKeyFromPathname(location?.pathname),
     [location?.pathname],
   );
-
   const [isMultiEnabled] = useIsMultiEnabled();
   const { t } = useNetworkingTranslation();
 
@@ -34,6 +33,7 @@ const NetworkPolicyDetailsPage: FC<NetworkPolicyPageNavProps> = ({ namespace }) 
       onSelect={(_, tabIndex: number | string) => {
         navigate(getNetworkPolicyURLTab(tabIndex, namespace || ALL_NAMESPACES));
       }}
+      unmountOnExit
     >
       <Tab
         eventKey={TAB_INDEXES.NETWORK}
@@ -60,4 +60,4 @@ const NetworkPolicyDetailsPage: FC<NetworkPolicyPageNavProps> = ({ namespace }) 
   );
 };
 
-export default NetworkPolicyDetailsPage;
+export default NetworkPolicyPage;


### PR DESCRIPTION


- fix bug adding unmountOnExit
- remove the label filter as networkpolicy and multinetwrokpolicy do not need them

**Before**


https://github.com/user-attachments/assets/e3d9b41c-8175-47fe-b821-c93f24cfa9c5



**After**

https://github.com/user-attachments/assets/f30379da-3762-49b4-9c6f-a53ba053810f

