### PR TITLE
OCPBUGS-41697: OCPBUGS-41698: Add annotation field in ingress details page

### DIFF
--- a/src/views/ingresses/details/tabs/details/components/IngressDetailsSection/IngressDetailsSection.tsx
+++ b/src/views/ingresses/details/tabs/details/components/IngressDetailsSection/IngressDetailsSection.tsx
@@ -8,6 +8,7 @@ import {
   Timestamp,
   useAccessReview,
   useAnnotationsModal,
+  useLabelsModal,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { DetailsItem } from '@utils/components/DetailsItem/DetailsItem';
 import { LabelList } from '@utils/components/DetailsItem/LabelList';
@@ -30,6 +31,7 @@ type IngressDetailsSectionProps = {
 const IngressDetailsSection: FC<IngressDetailsSectionProps> = ({ ingress }) => {
   const { t } = useNetworkingTranslation();
   const annotationsModalLauncher = useAnnotationsModal(ingress);
+  const labelsModalLauncher = useLabelsModal(ingress);
 
   const [canUpdate] = useAccessReview({
     group: IngressModel?.apiGroup,
@@ -59,7 +61,7 @@ const IngressDetailsSection: FC<IngressDetailsSectionProps> = ({ ingress }) => {
         editAsGroup
         label={t('Labels')}
         obj={ingress}
-        onEdit={annotationsModalLauncher}
+        onEdit={labelsModalLauncher}
         path="metadata.labels"
         valueClassName="details-item__value--labels"
       >
@@ -67,6 +69,17 @@ const IngressDetailsSection: FC<IngressDetailsSectionProps> = ({ ingress }) => {
           groupVersionKind={getGroupVersionKindForModel(IngressModel)}
           labels={getLabels(ingress)}
         />
+      </DetailsItem>
+      <DetailsItem
+        canEdit={canUpdate}
+        label={t('Annotations')}
+        obj={ingress}
+        onEdit={annotationsModalLauncher}
+        path="metadata.annotations"
+      >
+        {t('{{count}} annotation', {
+          count: Object.keys(ingress?.metadata?.annotations || {}).length,
+        })}
       </DetailsItem>
       <DetailsItem label={t('TLS certificate')}>
         <TLSCert ingress={ingress} />


### PR DESCRIPTION
**Before**

<img width="1920" alt="Screenshot 2024-09-11 at 14 31 14" src="https://github.com/user-attachments/assets/55515773-dd37-4fb9-9d43-f302715e97ff">


<img width="1920" alt="Screenshot 2024-09-11 at 14 32 58" src="https://github.com/user-attachments/assets/26b344a8-970c-4038-92fd-063d8d9a8708">


**After**

<img width="1920" alt="Screenshot 2024-09-11 at 14 31 49" src="https://github.com/user-attachments/assets/4350cf24-8dab-441e-8889-bc65c2240e35">


<img width="1920" alt="Screenshot 2024-09-11 at 14 32 35" src="https://github.com/user-attachments/assets/a4f5e98b-e7cd-41a7-981d-1a4afd330a46">
