### PR TITLE
OCPBUGS-41692: fix remove function

### DIFF
--- a/src/views/routes/form/AlternateService.tsx
+++ b/src/views/routes/form/AlternateService.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Controller, FieldArrayWithId, useFieldArray, useFormContext } from 'react-hook-form';
+import { Controller, FieldArrayWithId, useFormContext } from 'react-hook-form';
 
 import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import { ResourceIcon } from '@openshift-console/dynamic-plugin-sdk';
@@ -28,14 +28,18 @@ type AlternateServiceProps = {
   field: FieldArrayWithId<RouteKind, 'spec.alternateBackends', 'id'>;
   filteredServices: IoK8sApiCoreV1Service[];
   index: number;
+  remove: (index: number) => void;
 };
 
-const AlternateService: FC<AlternateServiceProps> = ({ field, filteredServices, index }) => {
+const AlternateService: FC<AlternateServiceProps> = ({
+  field,
+  filteredServices,
+  index,
+  remove,
+}) => {
   const { t } = useNetworkingTranslation();
 
   const { control, register } = useFormContext<RouteKind>();
-
-  const { remove } = useFieldArray({ control, name: 'spec.alternateBackends' });
 
   return (
     <Controller

--- a/src/views/routes/form/AlternateServicesSection.tsx
+++ b/src/views/routes/form/AlternateServicesSection.tsx
@@ -20,7 +20,7 @@ const AlternateServicesSection: FC<AlternateServicesSectionProps> = ({ services 
 
   const { control, watch } = useFormContext<RouteKind>();
 
-  const { append, fields } = useFieldArray({ control, name: 'spec.alternateBackends' });
+  const { append, fields, remove } = useFieldArray({ control, name: 'spec.alternateBackends' });
 
   const selectedServiceNames = watch('spec.alternateBackends')?.map((field) => field.name) || [];
   const filteredServices = (services || []).filter(
@@ -35,6 +35,7 @@ const AlternateServicesSection: FC<AlternateServicesSectionProps> = ({ services 
           filteredServices={filteredServices}
           index={index}
           key={field.id}
+          remove={remove}
         />
       ))}
 


### PR DESCRIPTION
The remove function should not be called by a different `useFieldArray` hook.
It should come from the same `useFieldArray` that is used to render the `AlternateService` array