### PR TITLE
OCPBUGS-41605: Fix lastnamespacepath with actual namespace

### DIFF
--- a/src/views/networkpolicies/list/EnableMultiPage.tsx
+++ b/src/views/networkpolicies/list/EnableMultiPage.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { modelToGroupVersionKind, modelToRef } from '@kubevirt-ui/kubevirt-api/console';
@@ -10,24 +10,29 @@ import {
   useK8sWatchResource,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
+  Alert,
+  AlertVariant,
   Button,
   EmptyState,
   EmptyStateActions,
+  EmptyStateBody,
   EmptyStateFooter,
   EmptyStateHeader,
   Tooltip,
 } from '@patternfly/react-core';
-import { useLastNamespacePath } from '@utils/hooks/useLastNamespacePath';
+import { ALL_NAMESPACES } from '@utils/constants';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { MultiNetworkPolicyModel } from '@utils/models';
 import { NetworkConfigModel } from '@views/nads/form/utils/constants';
 
 import '@styles/list-management-group.scss';
 
-const EnableMultiPage: FC = () => {
+type EnableMultiPageProps = { namespace: string };
+
+const EnableMultiPage: FC<EnableMultiPageProps> = ({ namespace }) => {
   const { t } = useNetworkingTranslation();
-  const lastNamespacePath = useLastNamespacePath();
   const navigate = useNavigate();
+  const [error, setError] = useState<Error | null>();
 
   const [networkClusterConfig, loaded] = useK8sWatchResource<K8sResourceCommon & { spec: any }>({
     groupVersionKind: modelToGroupVersionKind(NetworkConfigModel),
@@ -40,25 +45,29 @@ const EnableMultiPage: FC = () => {
     verb: 'patch' as K8sVerb,
   });
 
-  const enableMultiNetworkPolicy = () => {
-    k8sPatch({
-      data: [
-        {
-          op: 'replace',
-          path: '/spec/disableMultiNetwork',
-          value: false,
-        },
-        {
-          op: 'replace',
-          path: '/spec/useMultiNetworkPolicy',
-          value: true,
-        },
-      ],
-      model: NetworkConfigModel,
-      resource: networkClusterConfig,
-    }).then(() => {
-      navigate(`/k8s/${lastNamespacePath}/${modelToRef(MultiNetworkPolicyModel)}`);
-    });
+  const enableMultiNetworkPolicy = async () => {
+    setError(null);
+    try {
+      await k8sPatch({
+        data: [
+          {
+            op: 'replace',
+            path: '/spec/disableMultiNetwork',
+            value: false,
+          },
+          {
+            op: 'replace',
+            path: '/spec/useMultiNetworkPolicy',
+            value: true,
+          },
+        ],
+        model: NetworkConfigModel,
+        resource: networkClusterConfig,
+      });
+      navigate(`/k8s/${namespace || ALL_NAMESPACES}/${modelToRef(MultiNetworkPolicyModel)}`);
+    } catch (apiError) {
+      setError(apiError);
+    }
   };
 
   const EnableButton = (
@@ -73,6 +82,13 @@ const EnableMultiPage: FC = () => {
         headingLevel="h4"
         titleText={t('{{kind}} disabled', { kind: MultiNetworkPolicyModel.labelPlural })}
       />
+      {error && (
+        <EmptyStateBody>
+          <Alert title={t('Error')} variant={AlertVariant.danger}>
+            {error.message}
+          </Alert>
+        </EmptyStateBody>
+      )}
       <EmptyStateFooter>
         <EmptyStateActions>
           {canPatchConfig ? (

--- a/src/views/networkpolicies/list/NetworkPolicyPage.tsx
+++ b/src/views/networkpolicies/list/NetworkPolicyPage.tsx
@@ -53,7 +53,7 @@ const NetworkPolicyDetailsPage: FC<NetworkPolicyPageNavProps> = ({ namespace }) 
           eventKey={TAB_INDEXES.ENABLE_MULTI}
           title={<TabTitleText>{t('MultiNetworkPolicies')}</TabTitleText>}
         >
-          <EnableMultiPage />
+          <EnableMultiPage namespace={namespace} />
         </Tab>
       )}
     </Tabs>


### PR DESCRIPTION
just use the namespace that the consoel give us or all-namespaces if it's undefined. do not use lastnamespace here.

Error handling in the enable action

![Uploading Screenshot 2024-09-12 at 15.08.41.png…]()
