### PR TITLE
[release-4.17] OCPBUGS-41808:  normal user have to use projects no namespaces

### DIFF
--- a/src/views/networkpolicies/new/components/NetworkPolicySelectorPreview/components/hooks/useNetworkPolicyPodPreviewData.ts
+++ b/src/views/networkpolicies/new/components/NetworkPolicySelectorPreview/components/hooks/useNetworkPolicyPodPreviewData.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { NamespaceModel, PodModel } from '@kubevirt-ui/kubevirt-api/console';
+import { PodModel, ProjectModel } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1Pod } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import {
   K8sResourceCommon,
@@ -54,9 +54,8 @@ const useNetworkPolicyPodPreviewData: UseNetworkPolicyPodPreviewData = ({
 
   const [namespaces, loadedNamespaces, namespacesError] = useK8sWatchResource<K8sResourceCommon[]>({
     isList: true,
-    kind: NamespaceModel.kind,
-    namespace,
-    selector: safePodSelector,
+    kind: ProjectModel.kind,
+    selector: safeNsSelector,
   });
 
   return {


### PR DESCRIPTION
backporting https://github.com/openshift/networking-console-plugin/pull/79