### PR TITLE
OCPBUGS-41699: Add destination ca cert

### DIFF
--- a/src/views/routes/form/TLSTermination.tsx
+++ b/src/views/routes/form/TLSTermination.tsx
@@ -15,14 +15,17 @@ import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation'
 import {
   CA_CERTIFICATE_FIELD_ID,
   CERTIFICATE_FIELD_ID,
+  DESTINATION_CA_CERT_FIELD_ID,
   insecureTrafficTypes,
   KEY_FIELD_ID,
   PASSTHROUGH,
   passthroughInsecureTrafficTypes,
+  RE_ENCRYPT,
   terminationTypes,
   TLS_TERMINATION_FIELD_ID,
   TLS_TERMINATION_POLICY_FIELD_ID,
 } from './constants';
+import { omitCertificatesOnTypeChange } from './utils';
 
 const TLSTermination: FC = () => {
   const { t } = useNetworkingTranslation();
@@ -49,7 +52,11 @@ const TLSTermination: FC = () => {
                   <DropdownItem
                     key={type}
                     onClick={() =>
-                      onChange({ ...value, insecureEdgeTerminationPolicy: '', termination: type })
+                      onChange({
+                        ...omitCertificatesOnTypeChange(value, type),
+                        insecureEdgeTerminationPolicy: '',
+                        termination: type,
+                      })
                     }
                     value={type}
                   >
@@ -142,6 +149,29 @@ const TLSTermination: FC = () => {
                   value={value?.caCertificate}
                 />
               </FormGroup>
+
+              {terminationType === RE_ENCRYPT && (
+                <FormGroup
+                  fieldId={DESTINATION_CA_CERT_FIELD_ID}
+                  label={t('Destination CA certificate')}
+                >
+                  <FileUpload
+                    id={DESTINATION_CA_CERT_FIELD_ID}
+                    onClearClick={() => onChange({ ...value, destinationCACertificate: '' })}
+                    onDataChange={(event, data) =>
+                      onChange({ ...value, destinationCACertificate: data })
+                    }
+                    onFileInputChange={(event, data) =>
+                      onChange({ ...value, destinationCACertificate: data })
+                    }
+                    onTextChange={(event, data) =>
+                      onChange({ ...value, destinationCACertificate: data })
+                    }
+                    type="text"
+                    value={value?.destinationCACertificate}
+                  />
+                </FormGroup>
+              )}
             </>
           )}
           rules={{ required: false }}

--- a/src/views/routes/form/constants.ts
+++ b/src/views/routes/form/constants.ts
@@ -2,11 +2,13 @@ import { modelToGroupVersionKind, ServiceModel } from '@kubevirt-ui/kubevirt-api
 import { t } from '@utils/hooks/useNetworkingTranslation';
 
 export const PASSTHROUGH = 'passthrough';
+export const RE_ENCRYPT = 'reencrypt';
+export const EDGE = 'edge';
 
 export const terminationTypes = {
-  edge: t('Edge'),
+  [EDGE]: t('Edge'),
   [PASSTHROUGH]: t('Passthrough'),
-  reencrypt: t('Re-encrypt'),
+  [RE_ENCRYPT]: t('Re-encrypt'),
 };
 
 export const insecureTrafficTypes = {
@@ -33,4 +35,5 @@ export const TLS_TERMINATION_FIELD_ID = 'tls-termination';
 export const TLS_TERMINATION_POLICY_FIELD_ID = 'tls-insecureEdgeTerminationPolicy';
 export const CERTIFICATE_FIELD_ID = 'certificate';
 export const CA_CERTIFICATE_FIELD_ID = 'ca-certificate';
+export const DESTINATION_CA_CERT_FIELD_ID = 'destination-ca-certificate';
 export const KEY_FIELD_ID = 'key';

--- a/src/views/routes/form/utils.ts
+++ b/src/views/routes/form/utils.ts
@@ -1,6 +1,8 @@
 import { RouteModel } from '@kubevirt-ui/kubevirt-api/console';
-import { RouteKind } from '@utils/types';
+import { RouteKind, RouteTLS } from '@utils/types';
 import { generateName } from '@utils/utils';
+
+import { EDGE, PASSTHROUGH } from './constants';
 
 export const generateDefaultRoute = (namespace: string): RouteKind => ({
   apiVersion: `${RouteModel.apiGroup}/${RouteModel.apiVersion}`,
@@ -18,3 +20,25 @@ export const generateDefaultRoute = (namespace: string): RouteKind => ({
     },
   },
 });
+
+export const omitCertificatesOnTypeChange = (routeTLS: RouteTLS, terminationType: string) => {
+  if (terminationType === EDGE) {
+    return {
+      caCertificate: routeTLS.caCertificate,
+      certificate: routeTLS.certificate,
+      insecureEdgeTerminationPolicy: routeTLS.insecureEdgeTerminationPolicy,
+      key: routeTLS.key,
+      termination: routeTLS.termination,
+    };
+  }
+
+  if (terminationType === PASSTHROUGH) {
+    return {
+      insecureEdgeTerminationPolicy: routeTLS.insecureEdgeTerminationPolicy,
+      key: routeTLS.key,
+      termination: routeTLS.termination,
+    };
+  }
+
+  return routeTLS;
+};


### PR DESCRIPTION


**Before**

fields persistent even after termination type change

Destination CA cert not present

**After**

Add Destination CA cert (only for re-encrypt)

Make sure that when the user changes the termination type, we remove the unnecessary cert attributes

Passthrough does not want any cert
Re-encrypt also wants Destination CA 
edge does not want destination ca

https://github.com/user-attachments/assets/aebf0f25-be8c-4b4b-834a-46cf1bd9b15f

