### PR TITLE
OCPBUGS-39249: fix sorting on lists

### DIFF
--- a/src/views/ingresses/list/hooks/useIngressColumns.tsx
+++ b/src/views/ingresses/list/hooks/useIngressColumns.tsx
@@ -5,6 +5,7 @@ import { IoK8sApiNetworkingV1Ingress } from '@kubevirt-ui/kubevirt-api/kubernete
 import { TableColumn, useActiveColumns } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
+import { objectColumnSorting } from '@utils/utils/sorting';
 import { tableColumnClasses } from '@views/services/list/hooks/useServiceColumn';
 
 import { sortIngressesByHosts } from '../utils/utils';
@@ -33,7 +34,7 @@ const useIngressColumns: UseIngressColumns = () => {
       {
         id: 'labels',
         props: { className: tableColumnClasses[2] },
-        sort: 'metadata.labels',
+        sort: (data, direction) => objectColumnSorting(data, direction, null, 'metadata.labels'),
         title: t('Labels'),
         transforms: [sortable],
       },

--- a/src/views/networkpolicies/list/hooks/useNetworkPolicyColumn.tsx
+++ b/src/views/networkpolicies/list/hooks/useNetworkPolicyColumn.tsx
@@ -6,7 +6,7 @@ import { TableColumn, useActiveColumns } from '@openshift-console/dynamic-plugin
 import { sortable } from '@patternfly/react-table';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { PaginationState } from '@utils/hooks/usePagination/utils/types';
-import { columnSorting } from '@utils/utils/sorting';
+import { columnSorting, objectColumnSorting } from '@utils/utils/sorting';
 
 type UseNetworkPolicyListColumnsValues = [
   columns: TableColumn<IoK8sApiNetworkingV1NetworkPolicy>[],
@@ -26,6 +26,11 @@ const useNetworkPolicyColumn: UseNetworkPolicyListColumns = (pagination, data) =
     [data, pagination],
   );
 
+  const sortingObjects = useCallback(
+    (direction, path) => objectColumnSorting(data, direction, pagination, path),
+    [data, pagination],
+  );
+
   const columns: TableColumn<IoK8sApiNetworkingV1NetworkPolicy>[] = [
     {
       id: 'name',
@@ -42,7 +47,7 @@ const useNetworkPolicyColumn: UseNetworkPolicyListColumns = (pagination, data) =
     {
       id: 'pod-selector',
       props: { className: 'pf-m-hidden pf-m-visible-on-md' },
-      sort: (_, direction) => sorting(direction, 'spec.podSelector.matchLabels'),
+      sort: (_, direction) => sortingObjects(direction, 'spec.podSelector.matchLabels'),
       title: t('Pod selector'),
       transforms: [sortable],
     },

--- a/src/views/routes/list/hooks/useRouteColumns.ts
+++ b/src/views/routes/list/hooks/useRouteColumns.ts
@@ -6,6 +6,8 @@ import { sortable } from '@patternfly/react-table';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { RouteKind } from '@utils/types';
 
+import { sortRoutesByLocation } from '../utils/utils';
+
 export const tableColumnClasses = [
   'pf-v5-u-w-25-on-xl',
   'pf-m-hidden pf-m-visible-on-md',
@@ -44,7 +46,7 @@ const useRouteColumns: UseRouteColumns = () => {
       {
         id: 'location',
         props: { className: tableColumnClasses[3] },
-        sort: 'spec.host',
+        sort: (data, direction) => data?.sort(sortRoutesByLocation(direction)),
         title: t('Location'),
         transforms: [sortable],
       },

--- a/src/views/routes/list/utils/utils.ts
+++ b/src/views/routes/list/utils/utils.ts
@@ -78,3 +78,12 @@ export const getRouteLabel = (route: RouteKind): string => {
   }
   return label;
 };
+
+export const sortRoutesByLocation = (direction: string) => (a: RouteKind, b: RouteKind) => {
+  const { first, second } = direction === 'asc' ? { first: a, second: b } : { first: b, second: a };
+
+  const firstValue = getRouteLabel(first);
+  const secondValue = getRouteLabel(second);
+
+  return firstValue?.localeCompare(secondValue);
+};

--- a/src/views/services/list/components/ServiceRow.tsx
+++ b/src/views/services/list/components/ServiceRow.tsx
@@ -55,7 +55,7 @@ const ServiceRow: FC<ServiceRowType> = ({ activeColumnIDs, obj }) => {
           <Selector namespace={obj.metadata.namespace} selector={obj.spec.selector} />
         )}
       </TableData>
-      <TableData activeColumnIDs={activeColumnIDs} className={tableColumnClasses[2]} id="labels">
+      <TableData activeColumnIDs={activeColumnIDs} className={tableColumnClasses[4]} id="labels">
         <ServiceLocation service={obj} />
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="">

--- a/src/views/services/list/hooks/useServiceColumn.tsx
+++ b/src/views/services/list/hooks/useServiceColumn.tsx
@@ -5,6 +5,7 @@ import { IoK8sApiCoreV1Service } from '@kubevirt-ui/kubevirt-api/kubernetes/mode
 import { TableColumn, useActiveColumns } from '@openshift-console/dynamic-plugin-sdk';
 import { sortable } from '@patternfly/react-table';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
+import { objectColumnSorting } from '@utils/utils/sorting';
 
 export const tableColumnClasses = [
   'pf-v5-u-w-25-on-xl',
@@ -44,7 +45,7 @@ const useServiceColumn = (): { id: string; title: string }[] => {
       {
         id: 'pod-selector',
         props: { className: tableColumnClasses[3] },
-        sort: 'spec.selector',
+        sort: (data, direction) => objectColumnSorting(data, direction, null, 'spec.selector'),
         title: t('Pod selector'),
         transforms: [sortable],
       },


### PR DESCRIPTION


Fix sorting on object fields .

The path referring to is an object so comparing two objects as strings was not working. Sorting randomly.
Now the object is transformed as a string key=value and can order everything using this string


<img width="1920" alt="Screenshot 2024-09-17 at 14 32 40" src="https://github.com/user-attachments/assets/c5c21a84-573c-4636-a20b-a316eedfe5e6">
<img width="1920" alt="Screenshot 2024-09-17 at 14 32 51" src="https://github.com/user-attachments/assets/70eed964-6d7d-458b-aa5d-9fe6e0f2d007">
<img width="1920" alt="Screenshot 2024-09-17 at 14 32 54" src="https://github.com/user-attachments/assets/568dc45b-3091-4b3a-8ccc-b876ce2270fb">


<img width="1920" alt="Screenshot 2024-09-17 at 14 32 59" src="https://github.com/user-attachments/assets/ae4890f0-429e-46f6-9ba4-0dbc47cce94d">
