### PR TITLE
OCPBUGS-42134: fix html in translations

### DIFF
--- a/locales/en/plugin__networking-console-plugin.json
+++ b/locales/en/plugin__networking-console-plugin.json
@@ -304,7 +304,7 @@
   "This NetworkPolicy cannot be displayed in form. Please switch to the YAML editor.": "This NetworkPolicy cannot be displayed in form. Please switch to the YAML editor.",
   "This route splits traffic across multiple services.": "This route splits traffic across multiple services.",
   "TLS certificate": "TLS certificate",
-  "TLS certificates for edge and re-encrypt termination. If not specified, the router&apos;s default certificate is used.": "TLS certificates for edge and re-encrypt termination. If not specified, the router&apos;s default certificate is used.",
+  "TLS certificates for edge and re-encrypt termination. If not specified, the router's default certificate is used.": "TLS certificates for edge and re-encrypt termination. If not specified, the router's default certificate is used.",
   "TLS is not enabled": "TLS is not enabled",
   "TLS Settings": "TLS Settings",
   "TLS termination": "TLS termination",

--- a/src/views/routes/form/TLSTermination.tsx
+++ b/src/views/routes/form/TLSTermination.tsx
@@ -111,7 +111,7 @@ const TLSTermination: FC = () => {
 
               <Text component={TextVariants.p}>
                 {t(
-                  'TLS certificates for edge and re-encrypt termination. If not specified, the router&apos;s default certificate is used.',
+                  "TLS certificates for edge and re-encrypt termination. If not specified, the router's default certificate is used.",
                 )}
               </Text>
 


### PR DESCRIPTION
`&apos;` is html and it means `'`