### PR TITLE
CNV-48190: move title networkpolicies above tabs

### DIFF
--- a/src/utils/components/ListEmptyState/ListEmptyState.tsx
+++ b/src/utils/components/ListEmptyState/ListEmptyState.tsx
@@ -30,7 +30,7 @@ type ListEmptyStateProps<T> = {
   kind: string;
   learnMoreLink: string;
   loaded: boolean;
-  title: string;
+  title?: string;
 };
 
 const ListEmptyState = <T extends K8sResourceCommon>({
@@ -52,7 +52,7 @@ const ListEmptyState = <T extends K8sResourceCommon>({
   if (!loaded)
     return (
       <>
-        <ListPageHeader title={title} />
+        {title && <ListPageHeader title={title} />}
         <ListSkeleton />
       </>
     );
@@ -60,7 +60,7 @@ const ListEmptyState = <T extends K8sResourceCommon>({
   if (isEmpty(data))
     return (
       <>
-        <ListPageHeader title={title} />
+        {title && <ListPageHeader title={title} />}
         <EmptyState>
           <EmptyStateHeader
             headingLevel="h4"

--- a/src/utils/components/ListEmptyState/ListErrorState.tsx
+++ b/src/utils/components/ListEmptyState/ListErrorState.tsx
@@ -30,7 +30,7 @@ const ListErrorState: FC<ListErrorStateProps> = ({ error, title }) => {
   if (error?.response?.status === 403)
     return (
       <>
-        <ListPageHeader title={title} />
+        {title && <ListPageHeader title={title} />}
         <EmptyState className="list-error-state-root">
           <EmptyStateHeader
             headingLevel="h4"
@@ -52,7 +52,7 @@ const ListErrorState: FC<ListErrorStateProps> = ({ error, title }) => {
 
   return (
     <>
-      <ListPageHeader title={title} />
+      {title && <ListPageHeader title={title} />}
       <EmptyState className="list-error-state-root">
         <EmptyStateBody>
           <span className="error-text-body">{error?.message}</span>

--- a/src/views/networkpolicies/list/MultiNetworkPolicyList.tsx
+++ b/src/views/networkpolicies/list/MultiNetworkPolicyList.tsx
@@ -7,7 +7,6 @@ import {
   ListPageBody,
   ListPageCreateButton,
   ListPageFilter,
-  ListPageHeader,
   useK8sWatchResource,
   useListPageFilter,
   VirtualizedTable,
@@ -48,7 +47,6 @@ const MultiNetworkPolicyList: FC<MultiNetworkPolicyListProps> = ({ namespace }) 
   const { onPaginationChange, pagination } = usePagination();
   const [data, filteredData, onFilterChange] = useListPageFilter(multinetworkPolicies);
   const [columns, activeColumns] = useNetworkPolicyColumn(pagination, filteredData);
-  const title = t('MultiNetworkPolicies');
 
   const paginatedData = filteredData?.slice(pagination.startIndex, pagination.endIndex);
   return (
@@ -59,30 +57,27 @@ const MultiNetworkPolicyList: FC<MultiNetworkPolicyListProps> = ({ namespace }) 
       kind={MultiNetworkPolicyModel.kind}
       learnMoreLink="https://docs.openshift.com/container-platform/4.16/networking/multiple_networks/configuring-multi-network-policy.html"
       loaded={loaded}
-      title={title}
     >
-      <ListPageHeader title={title}>
-        {!isEmpty(data.length) && (
-          <ListPageCreateButton
-            className="list-page-create-button-margin"
-            createAccessReview={{
-              groupVersionKind: modelToGroupVersionKind(MultiNetworkPolicyModel),
-              namespace,
-            }}
-            onClick={() =>
-              navigate(
-                `${resourcePathFromModel(
-                  MultiNetworkPolicyModel,
-                  null,
-                  namespace || DEFAULT_NAMESPACE,
-                )}/${SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}`,
-              )
-            }
-          >
-            {t('Create MultiNetworkPolicy')}
-          </ListPageCreateButton>
-        )}
-      </ListPageHeader>
+      {!isEmpty(data.length) && (
+        <ListPageCreateButton
+          className="list-page-create-button-margin"
+          createAccessReview={{
+            groupVersionKind: modelToGroupVersionKind(MultiNetworkPolicyModel),
+            namespace,
+          }}
+          onClick={() =>
+            navigate(
+              `${resourcePathFromModel(
+                MultiNetworkPolicyModel,
+                null,
+                namespace || DEFAULT_NAMESPACE,
+              )}/${SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}`,
+            )
+          }
+        >
+          {t('Create MultiNetworkPolicy')}
+        </ListPageCreateButton>
+      )}
       <ListPageBody>
         <div className="list-management-group">
           <ListPageFilter

--- a/src/views/networkpolicies/list/NetworkPolicyList.tsx
+++ b/src/views/networkpolicies/list/NetworkPolicyList.tsx
@@ -7,7 +7,6 @@ import {
   ListPageBody,
   ListPageCreateButton,
   ListPageFilter,
-  ListPageHeader,
   useK8sWatchResource,
   useListPageFilter,
   VirtualizedTable,
@@ -47,7 +46,6 @@ const NetworkPolicyList: FC<NetworkPolicyListProps> = ({ namespace }) => {
   const { onPaginationChange, pagination } = usePagination();
   const [data, filteredData, onFilterChange] = useListPageFilter(networkPolicies);
   const [columns, activeColumns] = useNetworkPolicyColumn(pagination, filteredData);
-  const title = t('NetworkPolicies');
 
   return (
     <ListEmptyState<IoK8sApiNetworkingV1NetworkPolicy>
@@ -57,30 +55,27 @@ const NetworkPolicyList: FC<NetworkPolicyListProps> = ({ namespace }) => {
       kind={NetworkPolicyModel.kind}
       learnMoreLink="https://kubernetes.io/docs/concepts/services-networking/network-policies/"
       loaded={loaded}
-      title={title}
     >
-      <ListPageHeader title={t('NetworkPolicies')}>
-        {!isEmpty(data.length) && (
-          <ListPageCreateButton
-            className="list-page-create-button-margin"
-            createAccessReview={{
-              groupVersionKind: modelToGroupVersionKind(NetworkPolicyModel),
-              namespace,
-            }}
-            onClick={() =>
-              navigate(
-                `${resourcePathFromModel(
-                  NetworkPolicyModel,
-                  null,
-                  namespace || DEFAULT_NAMESPACE,
-                )}/${SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}`,
-              )
-            }
-          >
-            {t('Create NetworkPolicy')}
-          </ListPageCreateButton>
-        )}
-      </ListPageHeader>
+      {!isEmpty(data.length) && (
+        <ListPageCreateButton
+          className="list-page-create-button-margin"
+          createAccessReview={{
+            groupVersionKind: modelToGroupVersionKind(NetworkPolicyModel),
+            namespace,
+          }}
+          onClick={() =>
+            navigate(
+              `${resourcePathFromModel(
+                NetworkPolicyModel,
+                null,
+                namespace || DEFAULT_NAMESPACE,
+              )}/${SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}`,
+            )
+          }
+        >
+          {t('Create NetworkPolicy')}
+        </ListPageCreateButton>
+      )}
       <ListPageBody>
         <div className="list-management-group">
           <ListPageFilter

--- a/src/views/networkpolicies/list/NetworkPolicyPage.tsx
+++ b/src/views/networkpolicies/list/NetworkPolicyPage.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
+import { ListPageHeader } from '@openshift-console/dynamic-plugin-sdk';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import { ALL_NAMESPACES } from '@utils/constants';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
@@ -28,35 +29,42 @@ const NetworkPolicyPage: FC<NetworkPolicyPageNavProps> = ({ namespace }) => {
   const { t } = useNetworkingTranslation();
 
   return (
-    <Tabs
-      activeKey={locationTabKey}
-      onSelect={(_, tabIndex: number | string) => {
-        navigate(getNetworkPolicyURLTab(tabIndex, namespace || ALL_NAMESPACES));
-      }}
-      unmountOnExit
-    >
-      <Tab
-        eventKey={TAB_INDEXES.NETWORK}
-        title={<TabTitleText>{t('NetworkPolicies')}</TabTitleText>}
+    <>
+      <ListPageHeader
+        title={
+          locationTabKey === TAB_INDEXES.NETWORK ? t('NetworkPolicies') : t('MultiNetworkPolicies')
+        }
+      ></ListPageHeader>
+      <Tabs
+        activeKey={locationTabKey}
+        onSelect={(_, tabIndex: number | string) => {
+          navigate(getNetworkPolicyURLTab(tabIndex, namespace || ALL_NAMESPACES));
+        }}
+        unmountOnExit
       >
-        <NetworkPolicyList namespace={namespace} />
-      </Tab>
-      {isMultiEnabled ? (
         <Tab
-          eventKey={TAB_INDEXES.MULTI_NETWORK}
-          title={<TabTitleText>{t('MultiNetworkPolicies')}</TabTitleText>}
+          eventKey={TAB_INDEXES.NETWORK}
+          title={<TabTitleText>{t('NetworkPolicies')}</TabTitleText>}
         >
-          <MultiNetworkPolicyList namespace={namespace} />
+          <NetworkPolicyList namespace={namespace} />
         </Tab>
-      ) : (
-        <Tab
-          eventKey={TAB_INDEXES.ENABLE_MULTI}
-          title={<TabTitleText>{t('MultiNetworkPolicies')}</TabTitleText>}
-        >
-          <EnableMultiPage namespace={namespace} />
-        </Tab>
-      )}
-    </Tabs>
+        {isMultiEnabled ? (
+          <Tab
+            eventKey={TAB_INDEXES.MULTI_NETWORK}
+            title={<TabTitleText>{t('MultiNetworkPolicies')}</TabTitleText>}
+          >
+            <MultiNetworkPolicyList namespace={namespace} />
+          </Tab>
+        ) : (
+          <Tab
+            eventKey={TAB_INDEXES.ENABLE_MULTI}
+            title={<TabTitleText>{t('MultiNetworkPolicies')}</TabTitleText>}
+          >
+            <EnableMultiPage namespace={namespace} />
+          </Tab>
+        )}
+      </Tabs>
+    </>
   );
 };
 


### PR DESCRIPTION
To be consistent with other pages like Checkpus Preferences and InstanceType


**Before**

<img width="1920" alt="Screenshot 2024-09-25 at 09 27 57" src="https://github.com/user-attachments/assets/35e1c4ef-46df-495e-b931-4181314bf54f">
<img width="1920" alt="Screenshot 2024-09-25 at 09 27 53" src="https://github.com/user-attachments/assets/16f0a33d-10a6-4433-82d8-f0972204a77e">


**After**

<img width="1920" alt="Screenshot 2024-09-25 at 09 25 07" src="https://github.com/user-attachments/assets/4c015f00-39ae-4568-a7ae-66fb0cf2f9a3">
<img width="1920" alt="Screenshot 2024-09-25 at 09 25 12" src="https://github.com/user-attachments/assets/40adb0f5-adc7-418e-8517-dcbb73630781">
