### PR TITLE
OCPBUGS-42311: Route edit form

### DIFF
--- a/locales/en/plugin__networking-console-plugin.json
+++ b/locales/en/plugin__networking-console-plugin.json
@@ -114,6 +114,7 @@
   "Edge": "Edge",
   "Edit": "Edit",
   "Edit {{kind}}": "Edit {{kind}}",
+  "Edit {{label}}": "Edit {{label}}",
   "Edit annotations": "Edit annotations",
   "Edit Ingress": "Edit Ingress",
   "Edit labels": "Edit labels",

--- a/src/views/routes/actions/hooks/useRouteActions.ts
+++ b/src/views/routes/actions/hooks/useRouteActions.ts
@@ -40,7 +40,7 @@ const useRouteActions: UseRouteActions = (route) => {
     {
       accessReview: asAccessReview(RouteModel, route, 'update'),
       cta: () =>
-        history.push(`/k8s/ns/${routeNamespace}/${modelToRef(RouteModel)}/${routeName}/yaml`),
+        history.push(`/k8s/ns/${routeNamespace}/${modelToRef(RouteModel)}/${routeName}/form`),
       id: 'edit-routes',
       label: t('Edit Route'),
     },

--- a/src/views/routes/details/EditRoute.tsx
+++ b/src/views/routes/details/EditRoute.tsx
@@ -1,0 +1,28 @@
+import React, { FC } from 'react';
+import { useParams } from 'react-router-dom-v5-compat';
+
+import { modelToGroupVersionKind, RouteModel } from '@kubevirt-ui/kubevirt-api/console';
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import StatusBox from '@utils/components/StatusBox/StatusBox';
+import { RouteKind } from '@utils/types';
+
+import RouteFormPage from '../form/RouteFormPage';
+
+const RouteDetailsPage: FC = () => {
+  const params = useParams();
+
+  const [route, loaded, error] = useK8sWatchResource<RouteKind>({
+    groupVersionKind: modelToGroupVersionKind(RouteModel),
+    isList: false,
+    name: params.name,
+    namespace: params.namespace,
+  });
+
+  return (
+    <StatusBox error={error} loaded={loaded}>
+      <RouteFormPage initialRoute={route} />
+    </StatusBox>
+  );
+};
+
+export default RouteDetailsPage;

--- a/src/views/routes/form/RouteFormActions.tsx
+++ b/src/views/routes/form/RouteFormActions.tsx
@@ -8,9 +8,10 @@ import { isEmpty } from '@utils/utils';
 
 type RouteFormActionsProps = {
   apiError: Error;
+  isCreationForm?: boolean;
 };
 
-const RouteFormActions: FC<RouteFormActionsProps> = ({ apiError }) => {
+const RouteFormActions: FC<RouteFormActionsProps> = ({ apiError, isCreationForm }) => {
   const { t } = useNetworkingTranslation();
   const navigate = useNavigate();
   const {
@@ -32,7 +33,7 @@ const RouteFormActions: FC<RouteFormActionsProps> = ({ apiError }) => {
           type="submit"
           variant={ButtonVariant.primary}
         >
-          {t('Create')}
+          {isCreationForm ? t('Create') : t('Edit')}
         </Button>
         <Button
           id="cancel"

--- a/src/views/routes/form/RouteFormPage.tsx
+++ b/src/views/routes/form/RouteFormPage.tsx
@@ -13,24 +13,31 @@ import { EditorType } from '@utils/components/SyncedEditor/EditorToggle';
 import { SyncedEditor } from '@utils/components/SyncedEditor/SyncedEditor';
 import { safeYAMLToJS } from '@utils/components/SyncedEditor/yaml';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
+import { RouteKind } from '@utils/types';
 import { getValidNamespace } from '@utils/utils';
 import { LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY } from '@views/networkpolicies/new/utils/const';
 
 import RouteForm from './RouteForm';
 import { generateDefaultRoute } from './utils';
 
-const RouteFormPage: FC = () => {
+type RouteFormPageProps = { initialRoute?: RouteKind };
+
+const RouteFormPage: FC<RouteFormPageProps> = ({ initialRoute }) => {
   const { t } = useNetworkingTranslation();
 
   const [activeNamespace] = useActiveNamespace();
   const namespace = getValidNamespace(activeNamespace);
 
-  const k8sObj = generateDefaultRoute(namespace);
+  const k8sObj = initialRoute || generateDefaultRoute(namespace);
 
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
-        <Title headingLevel="h2">{t('Create {{label}}', { label: RouteModel.label })}</Title>
+        <Title headingLevel="h2">
+          {initialRoute
+            ? t('Edit {{label}}', { label: RouteModel.label })
+            : t('Create {{label}}', { label: RouteModel.label })}
+        </Title>
         <Text component={TextVariants.p}>
           {t('Routing is a way to make your application publicly visible')}
         </Text>

--- a/src/views/routes/form/useIsCreationForm.tsx
+++ b/src/views/routes/form/useIsCreationForm.tsx
@@ -1,0 +1,9 @@
+import { useLocation } from 'react-router-dom-v5-compat';
+
+const useIsCreationForm = (): boolean => {
+  const location = useLocation();
+
+  return location?.pathname.includes('~new/form');
+};
+
+export default useIsCreationForm;

--- a/src/views/routes/form/utils.ts
+++ b/src/views/routes/form/utils.ts
@@ -13,7 +13,6 @@ export const generateDefaultRoute = (namespace: string): RouteKind => ({
   },
   spec: {
     path: '/',
-    tls: null,
     to: {
       kind: 'Service',
       name: '',

--- a/src/views/routes/manifest.ts
+++ b/src/views/routes/manifest.ts
@@ -65,9 +65,20 @@ export const RoutesExtensions: EncodedExtension[] = [
     },
     type: 'console.page/route',
   } as EncodedExtension<RoutePage>,
+  {
+    properties: {
+      component: {
+        $codeRef: 'EditRoute',
+      },
+      exact: true,
+      path: ['/k8s/ns/:namespace/route.openshift.io~v1~Route/:name/form'],
+    },
+    type: 'console.page/route',
+  } as EncodedExtension<RoutePage>,
 ];
 
 export const RoutesExposedModules: ConsolePluginBuildMetadata['exposedModules'] = {
+  EditRoute: './views/routes/details/EditRoute.tsx',
   RouteDetails: './views/routes/details/RouteDetailsPage.tsx',
   RouteFormPage: './views/routes/form/RouteFormPage.tsx',
   RoutesList: './views/routes/list/RoutesList.tsx',


### PR DESCRIPTION


Edit route form. Before this the edit route action was just a link to the yaml details page


https://github.com/user-attachments/assets/ceee1e72-5bc2-42b1-a2f4-ae9daf62c76f

