### PR TITLE
OCPBUGS-42354: hide routes metrics non-admin users

### DIFF
--- a/src/views/routes/details/hooks/useRouteTabs.ts
+++ b/src/views/routes/details/hooks/useRouteTabs.ts
@@ -1,3 +1,4 @@
+import { useIsAdmin } from '@utils/hooks/useIsAdmin';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import RouteDetailsTab from '@views/routes/details/components/tabs/detailsTab/RouteDetailsTab';
 import RouteMetricsTab from '@views/routes/details/components/tabs/metricsTab/RouteMetricsTab';
@@ -5,6 +6,7 @@ import RouteYAMLTab from '@views/routes/details/components/tabs/yamlTab/RouteYAM
 
 const useRouteTabs = () => {
   const { t } = useNetworkingTranslation();
+  const isAdmin = useIsAdmin();
 
   return [
     {
@@ -12,11 +14,15 @@ const useRouteTabs = () => {
       href: '',
       name: t('Details'),
     },
-    {
-      component: RouteMetricsTab,
-      href: 'metrics',
-      name: t('Metrics'),
-    },
+    ...(isAdmin
+      ? [
+          {
+            component: RouteMetricsTab,
+            href: 'metrics',
+            name: t('Metrics'),
+          },
+        ]
+      : []),
     {
       component: RouteYAMLTab,
       href: 'yaml',


### PR DESCRIPTION
Non admin users do not have access to routes metrics

**Before**

<img width="1920" alt="Screenshot 2024-10-09 at 10 05 29" src="https://github.com/user-attachments/assets/21484eb2-58d7-43a0-b43e-f1b1d7403701">

**After**


<img width="1920" alt="Screenshot 2024-10-09 at 10 04 30" src="https://github.com/user-attachments/assets/60c53ff8-4ef4-40d9-be91-3750f397eafc">
