### PR TITLE
OCPBUGS-43034: Routes list sort by status

### DIFF
--- a/src/views/routes/list/hooks/useRouteColumns.ts
+++ b/src/views/routes/list/hooks/useRouteColumns.ts
@@ -6,7 +6,7 @@ import { sortable } from '@patternfly/react-table';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { RouteKind } from '@utils/types';
 
-import { sortRoutesByLocation } from '../utils/utils';
+import { sortRoutesByLocation, sortRoutesByStatus } from '../utils/utils';
 
 export const tableColumnClasses = [
   'pf-v5-u-w-25-on-xl',
@@ -41,7 +41,9 @@ const useRouteColumns: UseRouteColumns = () => {
       {
         id: 'status',
         props: { className: tableColumnClasses[2] },
+        sort: (data, direction) => data?.sort(sortRoutesByStatus(direction)),
         title: t('Status'),
+        transforms: [sortable],
       },
       {
         id: 'location',

--- a/src/views/routes/list/utils/utils.ts
+++ b/src/views/routes/list/utils/utils.ts
@@ -87,3 +87,12 @@ export const sortRoutesByLocation = (direction: string) => (a: RouteKind, b: Rou
 
   return firstValue?.localeCompare(secondValue);
 };
+
+export const sortRoutesByStatus = (direction: string) => (a: RouteKind, b: RouteKind) => {
+  const { first, second } = direction === 'asc' ? { first: a, second: b } : { first: b, second: a };
+
+  const firstValue = routeStatus(first);
+  const secondValue = routeStatus(second);
+
+  return firstValue?.localeCompare(secondValue);
+};


### PR DESCRIPTION

Add status list sorting 


**Before**

No status order

**After**

<img width="1915" alt="Screenshot 2024-10-10 at 15 12 38" src="https://github.com/user-attachments/assets/b8a2a628-1c9d-42fd-9f53-82a6021eecbb">
<img width="1915" alt="Screenshot 2024-10-10 at 15 12 43" src="https://github.com/user-attachments/assets/bbfca095-93aa-4a75-9c99-e2c5357d0a9d">
