### PR TITLE
OCPBUGS-43873 Routes list page shows correct status and location

### DIFF
--- a/src/views/routes/list/RoutesList.tsx
+++ b/src/views/routes/list/RoutesList.tsx
@@ -36,23 +36,15 @@ const RoutesList: FC<RoutesListProps> = ({ namespace }) => {
     namespace,
   });
 
-  const routes = routesFetch.map((route, index) => {
-    if (index % 2 === 0) {
-      route.status.ingress = null;
-    }
-
-    return route;
-  });
-
   const routeFilters = useRouteFilters();
-  const [data, filteredData, onFilterChange] = useListPageFilter(routes, routeFilters);
+  const [data, filteredData, onFilterChange] = useListPageFilter(routesFetch, routeFilters);
   const columns = useRouteColumns();
   const title = t('Routes');
 
   return (
     <ListEmptyState<RouteKind>
       createButtonlink={SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}
-      data={routes}
+      data={routesFetch}
       error={loadError}
       kind={RouteModel.kind}
       learnMoreLink="https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/networking/configuring-routes"


### PR DESCRIPTION
Before
within one project
<img width="1436" alt="Screenshot 2024-10-28 at 6 26 15 PM" src="https://github.com/user-attachments/assets/ee30aab9-f9ab-4337-8a9e-cb6ef94e2772">

`All Projects` selected
<img width="1439" alt="Screenshot 2024-10-28 at 6 26 05 PM" src="https://github.com/user-attachments/assets/a8f55d89-2519-4b72-a95d-abf107cf0901">


After
within one project
<img width="1440" alt="Screenshot 2024-10-28 at 6 24 22 PM" src="https://github.com/user-attachments/assets/adbc9f61-0e72-4268-be81-4273fa255480">

`All Projects` selected
<img width="1438" alt="Screenshot 2024-10-28 at 6 24 38 PM" src="https://github.com/user-attachments/assets/fe9d7b2d-f385-4bdc-98ab-67a15bacf8f1">
