### PR TITLE
CNV-52127: remove `t` calls that are not within components

### DIFF
--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -1,6 +1,3 @@
-export * from './nads';
-export * from './udns';
-
 export const ALL_NAMESPACES_KEY = '#ALL_NS#';
 export const ALL_NAMESPACES = 'all-namespaces';
 export const DEFAULT_NAMESPACE = 'default';

--- a/src/utils/constants/nads.ts
+++ b/src/utils/constants/nads.ts
@@ -1,3 +1,0 @@
-import { t } from '@utils/hooks/useNetworkingTranslation';
-
-export const NET_ATTACH_DEF_HEADER_LABEL = t('Create NetworkAttachmentDefinition');

--- a/src/utils/constants/udns.ts
+++ b/src/utils/constants/udns.ts
@@ -1,4 +1,0 @@
-import { t } from '@utils/hooks/useNetworkingTranslation';
-
-export const CUDN_HEADER_LABEL = t('Create ClusterUserDefinedNetwork');
-export const UDN_HEADER_LABEL = t('Create UserDefinedNetwork');

--- a/src/utils/models/index.ts
+++ b/src/utils/models/index.ts
@@ -1,7 +1,6 @@
 export * from './network-policy';
 import { modelToGroupVersionKind, modelToRef } from '@kubevirt-ui/kubevirt-api/console';
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
-import { t } from '@utils/hooks/useNetworkingTranslation';
 
 export const QuickStartModel: K8sModel = {
   abbr: 'CQS',
@@ -50,9 +49,11 @@ export const NetworkOperatorModel: K8sModel = {
   id: 'Network',
   kind: 'Network',
   label: 'network',
-  labelKey: t('network'),
+  // t('plugin__networking-console-plugin~network')
+  labelKey: 'network',
   labelPlural: 'Networks',
-  labelPluralKey: t('networks'),
+  // t('plugin__networking-console-plugin~networks')
+  labelPluralKey: 'networks',
   namespaced: false,
   plural: 'networks',
 };
@@ -65,9 +66,11 @@ export const UserDefinedNetworkModel: K8sModel = {
   id: 'userdefinednetwork',
   kind: 'UserDefinedNetwork',
   label: 'userdefinednetwork',
-  labelKey: t('UserDefinedNetwork'),
+  // t('plugin__networking-console-plugin~UserDefinedNetwork')
+  labelKey: 'UserDefinedNetwork',
   labelPlural: 'UserDefinedNetworks',
-  labelPluralKey: t('UserDefinedNetworks'),
+  // t('plugin__networking-console-plugin~UserDefinedNetworks')
+  labelPluralKey: 'UserDefinedNetworks',
   namespaced: true,
   plural: 'userdefinednetworks',
 };
@@ -84,9 +87,11 @@ export const ClusterUserDefinedNetworkModel: K8sModel = {
   id: 'clusteruserdefinednetwork',
   kind: 'ClusterUserDefinedNetwork',
   label: 'clusteruserdefinednetwork',
-  labelKey: t('ClusterUserDefinedNetwork'),
+  // t('plugin__networking-console-plugin~ClusterUserDefinedNetwork')
+  labelKey: 'ClusterUserDefinedNetwork',
   labelPlural: 'ClusterUserDefinedNetworks',
-  labelPluralKey: t('ClusterUserDefinedNetworks'),
+  // t('plugin__networking-console-plugin~ClusterUserDefinedNetworks')
+  labelPluralKey: 'ClusterUserDefinedNetworks',
   namespaced: false,
   plural: 'clusteruserdefinednetworks',
 };

--- a/src/views/nads/form/NetworkAttachmentDefinitionFormPage.tsx
+++ b/src/views/nads/form/NetworkAttachmentDefinitionFormPage.tsx
@@ -5,33 +5,37 @@ import { PageSection, PageSectionVariants, Title } from '@patternfly/react-core'
 import { EditorType } from '@utils/components/SyncedEditor/EditorToggle';
 import { SyncedEditor } from '@utils/components/SyncedEditor/SyncedEditor';
 import { safeYAMLToJS } from '@utils/components/SyncedEditor/yaml';
-import { t } from '@utils/hooks/useNetworkingTranslation';
+import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY } from '@views/networkpolicies/new/utils/const';
 
 import { generateDefaultNAD } from './utils/constants';
 import NetworkAttachmentDefinitionForm from './NetworkAttachmentDefinitionForm';
 
-const NetworkAttachmentDefinitionFormPage: FC = () => (
-  <>
-    <PageSection variant={PageSectionVariants.light}>
-      <Title headingLevel="h1">{t('Create NetworkAttachmentDefinition')}</Title>
-    </PageSection>
-    <SyncedEditor
-      displayConversionError
-      FormEditor={NetworkAttachmentDefinitionForm}
-      initialData={generateDefaultNAD()}
-      initialType={EditorType.Form}
-      lastViewUserSettingKey={LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY}
-      YAMLEditor={({ initialYAML = '', onChange }) => (
-        <ResourceYAMLEditor
-          create
-          hideHeader
-          initialResource={safeYAMLToJS(initialYAML)}
-          onChange={onChange}
-        />
-      )}
-    />
-  </>
-);
+const NetworkAttachmentDefinitionFormPage: FC = () => {
+  const { t } = useNetworkingTranslation();
+
+  return (
+    <>
+      <PageSection variant={PageSectionVariants.light}>
+        <Title headingLevel="h1">{t('Create NetworkAttachmentDefinition')}</Title>
+      </PageSection>
+      <SyncedEditor
+        displayConversionError
+        FormEditor={NetworkAttachmentDefinitionForm}
+        initialData={generateDefaultNAD()}
+        initialType={EditorType.Form}
+        lastViewUserSettingKey={LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY}
+        YAMLEditor={({ initialYAML = '', onChange }) => (
+          <ResourceYAMLEditor
+            create
+            hideHeader
+            initialResource={safeYAMLToJS(initialYAML)}
+            onChange={onChange}
+          />
+        )}
+      />
+    </>
+  );
+};
 
 export default NetworkAttachmentDefinitionFormPage;

--- a/src/views/nads/form/NetworkAttachmentDefinitionFormPage.tsx
+++ b/src/views/nads/form/NetworkAttachmentDefinitionFormPage.tsx
@@ -5,7 +5,7 @@ import { PageSection, PageSectionVariants, Title } from '@patternfly/react-core'
 import { EditorType } from '@utils/components/SyncedEditor/EditorToggle';
 import { SyncedEditor } from '@utils/components/SyncedEditor/SyncedEditor';
 import { safeYAMLToJS } from '@utils/components/SyncedEditor/yaml';
-import { NET_ATTACH_DEF_HEADER_LABEL } from '@utils/constants';
+import { t } from '@utils/hooks/useNetworkingTranslation';
 import { LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY } from '@views/networkpolicies/new/utils/const';
 
 import { generateDefaultNAD } from './utils/constants';
@@ -14,7 +14,7 @@ import NetworkAttachmentDefinitionForm from './NetworkAttachmentDefinitionForm';
 const NetworkAttachmentDefinitionFormPage: FC = () => (
   <>
     <PageSection variant={PageSectionVariants.light}>
-      <Title headingLevel="h1">{NET_ATTACH_DEF_HEADER_LABEL}</Title>
+      <Title headingLevel="h1">{t('Create NetworkAttachmentDefinition')}</Title>
     </PageSection>
     <SyncedEditor
       displayConversionError

--- a/src/views/udns/form/UserDefinedNetworkFormPage.tsx
+++ b/src/views/udns/form/UserDefinedNetworkFormPage.tsx
@@ -6,7 +6,7 @@ import { PageSection, PageSectionVariants, Title } from '@patternfly/react-core'
 import { EditorType } from '@utils/components/SyncedEditor/EditorToggle';
 import { SyncedEditor } from '@utils/components/SyncedEditor/SyncedEditor';
 import { safeYAMLToJS } from '@utils/components/SyncedEditor/yaml';
-import { CUDN_HEADER_LABEL, UDN_HEADER_LABEL } from '@utils/constants';
+import { t } from '@utils/hooks/useNetworkingTranslation';
 
 import {
   generateDefaultCUDN,
@@ -17,6 +17,9 @@ import UserDefinedNetworkForm from './UserDefinedNetworkForm';
 
 const UserDefinedNetworkFormPage: FC = () => {
   const params = useParams();
+
+  const UDN_HEADER_LABEL = t('Create UserDefinedNetwork');
+  const CUDN_HEADER_LABEL = t('Create ClusterUserDefinedNetwork');
 
   return (
     <>

--- a/src/views/udns/form/UserDefinedNetworkFormPage.tsx
+++ b/src/views/udns/form/UserDefinedNetworkFormPage.tsx
@@ -6,7 +6,7 @@ import { PageSection, PageSectionVariants, Title } from '@patternfly/react-core'
 import { EditorType } from '@utils/components/SyncedEditor/EditorToggle';
 import { SyncedEditor } from '@utils/components/SyncedEditor/SyncedEditor';
 import { safeYAMLToJS } from '@utils/components/SyncedEditor/yaml';
-import { t } from '@utils/hooks/useNetworkingTranslation';
+import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 
 import {
   generateDefaultCUDN,
@@ -17,6 +17,8 @@ import UserDefinedNetworkForm from './UserDefinedNetworkForm';
 
 const UserDefinedNetworkFormPage: FC = () => {
   const params = useParams();
+
+  const { t } = useNetworkingTranslation();
 
   const UDN_HEADER_LABEL = t('Create UserDefinedNetwork');
   const CUDN_HEADER_LABEL = t('Create ClusterUserDefinedNetwork');


### PR DESCRIPTION
<h2 id="feature-fix">CONSOLE Features and Fixes:</h2>

https://issues.redhat.com/browse/CNV-52127

<h2 id="solution-description">Solution description</h2> 
<!-- Describe your code changes in detail and explain the solution or functionality -->

There was a race condition between reading the i18n resource json and trying to translate certain keys, notably ones where the `t` function is called within a constant instead of another React hook or React component. This PR moves the calling of those `t` functions to when they're used by the React components

<h2 id="reviewers-and-assignees">Reviewers and assignees:</h2>

/cc @upalatucci 

## Additional info

There should be additional checks in the dynamic plugins (e.g., running `e2e-gcp-console`) so that i18n issues don't happen as often (as it did this time and with other plugins). pinging @rhamilto @spadgett about implementing that

<h2 id="screenshots">Screen shots / gifs / design review:</h2>
<!-- Add screenshots or gifs for visual changes. Be sure to include before and after where relevant -->

n/a