### PR TITLE
CNV-46603: select projects with multitypeahead

### DIFF
--- a/src/utils/components/SelectMultiTypeahead/utils.ts
+++ b/src/utils/components/SelectMultiTypeahead/utils.ts
@@ -6,7 +6,9 @@ import { NO_RESULTS_VALUE } from './constants';
 
 export const filterOptions = (options: SelectOptionProps[], inputValue: string) => {
   const filteredOptions = options.filter((menuItem) =>
-    String(menuItem.children).toLowerCase().includes(inputValue.toLowerCase()),
+    String(menuItem.value || menuItem.children)
+      .toLowerCase()
+      .includes(inputValue.toLowerCase()),
   );
 
   if (isEmpty(filteredOptions)) {

--- a/src/utils/resources/udns/constants.ts
+++ b/src/utils/resources/udns/constants.ts
@@ -1,0 +1,1 @@
+export const PROJECT_LABEL_FOR_MATCH_EXPRESSION = 'kubernetes.io/metadata.name';

--- a/src/views/createprojectmodal/CreateProjectModal.tsx
+++ b/src/views/createprojectmodal/CreateProjectModal.tsx
@@ -2,27 +2,19 @@ import React, { FC, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
-import {
-  NamespaceModel,
-  ProjectModel,
-  ProjectRequestModel,
-} from '@kubevirt-ui/kubevirt-api/console';
-import {
-  k8sCreate,
-  k8sDelete,
-  k8sPatch,
-  K8sResourceCommon,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { ProjectModel, ProjectRequestModel } from '@kubevirt-ui/kubevirt-api/console';
+import { k8sCreate, k8sDelete, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-core';
 import ExternalLink from '@utils/components/ExternalLink/ExternalLink';
 import { documentationURLs, getDocumentationURL, isManaged } from '@utils/constants/documentation';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { UserDefinedNetworkModel } from '@utils/models';
-import { getResourceURL } from '@utils/resources/shared';
+import { getName, getResourceURL } from '@utils/resources/shared';
 
 import CreateProjectModalForm from './components/CreateProjectModalForm';
 import { initialFormState } from './constants';
 import { CreateProjectModalFormState, NETWORK_TYPE } from './types';
+import { patchClusterUDN } from './utils';
 
 import './CreateProjectModal.scss';
 
@@ -54,25 +46,10 @@ const CreateProjectModal: FC<{
       const projectCreated = await k8sCreate({ data: project, model: ProjectRequestModel });
 
       if (networkType === NETWORK_TYPE.UDN)
-        await k8sCreate({ data: udn, model: UserDefinedNetworkModel }).catch((err) => {
-          k8sDelete({ model: ProjectModel, resource: projectCreated });
-          throw err;
-        });
+        await k8sCreate({ data: udn, model: UserDefinedNetworkModel });
 
       if (networkType === NETWORK_TYPE.CLUSTER_UDN) {
-        const labelsToAdd = Object.entries(clusterUDN.spec.namespaceSelector.matchLabels || {}).map(
-          ([labelKey, labelValue]) => ({
-            op: 'add',
-            path: `/metadata/labels/${labelKey}`,
-            value: labelValue,
-          }),
-        );
-
-        await k8sPatch({
-          data: [{ op: 'add', path: '/metadata/labels', value: {} }, ...labelsToAdd],
-          model: NamespaceModel,
-          resource: projectCreated,
-        });
+        await patchClusterUDN(clusterUDN, getName(project));
       }
 
       closeModal();
@@ -83,6 +60,8 @@ const CreateProjectModal: FC<{
       }
       setErrorMessage('');
     } catch (error) {
+      k8sDelete({ model: ProjectModel, resource: project });
+
       setErrorMessage(error?.message || t('An error occurred. Please try again.'));
     }
   };

--- a/src/views/createprojectmodal/utils.ts
+++ b/src/views/createprojectmodal/utils.ts
@@ -1,0 +1,45 @@
+import { k8sPatch, Operator } from '@openshift-console/dynamic-plugin-sdk';
+import { ClusterUserDefinedNetworkModel } from '@utils/models';
+import { PROJECT_LABEL_FOR_MATCH_EXPRESSION } from '@utils/resources/udns/constants';
+import { ClusterUserDefinedNetworkKind } from '@utils/resources/udns/types';
+
+export const patchClusterUDN = async (
+  clusterUDN: ClusterUserDefinedNetworkKind,
+  projectName: string,
+) => {
+  const projectMatchExpressionIndex =
+    clusterUDN?.spec?.namespaceSelector?.matchExpressions?.findIndex(
+      (expression) => expression.key === PROJECT_LABEL_FOR_MATCH_EXPRESSION,
+    );
+
+  const currentUDNProjects =
+    clusterUDN?.spec?.namespaceSelector?.matchExpressions?.[projectMatchExpressionIndex]?.values;
+
+  const patchMatchExpression =
+    projectMatchExpressionIndex === -1
+      ? [
+          { op: 'add', path: '/spec/namespaceSelector/matchExpressions', value: [] },
+          {
+            op: 'add',
+            path: `/spec/namespaceSelector/matchExpressions/`,
+            value: {
+              key: PROJECT_LABEL_FOR_MATCH_EXPRESSION,
+              operator: Operator.In,
+              values: [projectName],
+            },
+          },
+        ]
+      : [
+          {
+            op: 'replace',
+            path: `/spec/namespaceSelector/matchExpressions/${projectMatchExpressionIndex}/values`,
+            value: [...currentUDNProjects, projectName],
+          },
+        ];
+
+  await k8sPatch({
+    data: patchMatchExpression,
+    model: ClusterUserDefinedNetworkModel,
+    resource: clusterUDN,
+  });
+};

--- a/src/views/udns/list/components/utils.ts
+++ b/src/views/udns/list/components/utils.ts
@@ -1,4 +1,3 @@
-import { K8sResourceCommon, MatchLabels } from '@openshift-console/dynamic-plugin-sdk';
 import { ALL_NAMESPACES_KEY, DEFAULT_NAMESPACE } from '@utils/constants';
 import { ClusterUserDefinedNetworkModel, UserDefinedNetworkModel } from '@utils/models';
 import {
@@ -34,7 +33,7 @@ export const createClusterUDN = (name: string): ClusterUserDefinedNetworkKind =>
     name,
   },
   spec: {
-    namespaceSelector: { matchLabels: {} },
+    namespaceSelector: { matchExpressions: [] },
     network: {
       layer2: {
         ipamLifecycle: 'Persistent',
@@ -54,8 +53,3 @@ export const getDefaultUDN = (isClusterUDN: boolean, namespace: string): UDNForm
         namespace === ALL_NAMESPACES_KEY ? DEFAULT_NAMESPACE : namespace,
       );
 };
-
-export const match = (resource: K8sResourceCommon, matchLabels: MatchLabels) =>
-  Object.entries(matchLabels || {})?.every(
-    ([key, value]) => resource?.metadata?.labels?.[key] === value,
-  );


### PR DESCRIPTION
For user is difficult to use matchLabels. Use Project selection with `matchExpressions`


use `matchExpressions` also to add projects to a ClusterUDN in the project creation modal


**Before**

<img width="1915" alt="Screenshot 2024-12-09 at 17 07 44" src="https://github.com/user-attachments/assets/73c6bbf4-faf1-490e-9c77-9e4b8202ca0d">


**After**


https://github.com/user-attachments/assets/d58414ef-750c-470f-91d4-b77b43fdfda5

https://github.com/user-attachments/assets/b35306e5-e03c-459b-91d2-d0a516968815
