### PR TITLE
OCPBUGS-45050: UI crash accessing a Service in pending state

### DIFF
--- a/src/views/services/details/tabs/details/ServiceAddress.tsx
+++ b/src/views/services/details/tabs/details/ServiceAddress.tsx
@@ -11,28 +11,28 @@ const ServiceAddress: FC<{ service: IoK8sApiCoreV1Service }> = ({ service }) => 
     switch (type) {
       case 'NodePort':
         return ServiceIPsRow({
-          name: t('Node port'),
           desc: t('Accessible outside the cluster'),
           ips: service?.spec?.ports?.map((port) => port.nodePort.toString()),
+          name: t('Node port'),
           note: t('(all nodes): '),
-      });
+        });
       case 'LoadBalancer':
         return ServiceIPsRow({
-          name: t('External load balancer'),
           desc: t('Ingress points of load balancer'),
           ips: service?.status?.loadBalancer?.ingress?.map((i) => i.hostname || i.ip || '-'),
+          name: t('External load balancer'),
         });
       case 'ExternalName':
         return ServiceIPsRow({
-          name: t('External service name'),
           desc: t('Location of the resource that backs the service'),
           ips: [service?.spec?.externalName],
+          name: t('External service name'),
         });
       default:
-        return ServiceIPsRow({ 
-          name: t('Cluster IP'), 
+        return ServiceIPsRow({
           desc: t('Accessible within the cluster only'),
-          ips: [ service?.spec?.clusterIP, ]
+          ips: [service?.spec?.clusterIP],
+          name: t('Cluster IP'),
         });
     }
   };
@@ -47,16 +47,21 @@ const ServiceAddress: FC<{ service: IoK8sApiCoreV1Service }> = ({ service }) => 
         {ServiceType(service.spec.type)}
         {service.spec.externalIPs &&
           ServiceIPsRow({
-            name: t('External IP'),
             desc: t('IP Addresses accepting traffic for service'),
             ips: service?.spec?.externalIPs,
+            name: t('External IP'),
           })}
       </div>
     </div>
   );
 };
 
-const ServiceIPsRow: FC<{ name:string, desc:string, ips: string[], note?:string }> = ({ name, desc, ips, note = null} ) => {
+const ServiceIPsRow: FC<{ desc: string; ips: string[]; name: string; note?: string }> = ({
+  desc,
+  ips,
+  name,
+  note = null,
+}) => {
   const { t } = useNetworkingTranslation();
 
   return (
@@ -67,12 +72,11 @@ const ServiceIPsRow: FC<{ name:string, desc:string, ips: string[], note?:string 
           <p className="ip-desc">{desc}</p>
         </div>
         <div className="col-xs-6">
-          {note && <MutedText content={note} isSpan />}
-          {ips ? ips.join(', '): t('Pending')}
+          {note && <MutedText content={note} isSpan />};{ips ? ips.join(', ') : t('Pending')}
         </div>
       </div>
     </div>
-  )
+  );
 };
 
 export default ServiceAddress;

--- a/src/views/services/details/tabs/details/ServiceAddress.tsx
+++ b/src/views/services/details/tabs/details/ServiceAddress.tsx
@@ -6,46 +6,34 @@ import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation'
 
 const ServiceAddress: FC<{ service: IoK8sApiCoreV1Service }> = ({ service }) => {
   const { t } = useNetworkingTranslation();
-  const ServiceIPsRow = (name, desc, ips, note = null) => (
-    <div className="co-ip-row">
-      <div className="row">
-        <div className="col-xs-6">
-          <p className="ip-name">{name}</p>
-          <p className="ip-desc">{desc}</p>
-        </div>
-        <div className="col-xs-6">
-          {note && <MutedText content={note} isSpan />}
-          {ips.join(', ')}
-        </div>
-      </div>
-    </div>
-  );
 
   const ServiceType = (type) => {
     switch (type) {
       case 'NodePort':
-        return ServiceIPsRow(
-          t('Node port'),
-          t('Accessible outside the cluster'),
-          service?.spec?.ports?.map((port) => port.nodePort),
-          t('(all nodes): '),
-        );
+        return ServiceIPsRow({
+          name: t('Node port'),
+          desc: t('Accessible outside the cluster'),
+          ips: service?.spec?.ports?.map((port) => port.nodePort.toString()),
+          note: t('(all nodes): '),
+      });
       case 'LoadBalancer':
-        return ServiceIPsRow(
-          t('External load balancer'),
-          t('Ingress points of load balancer'),
-          service?.status?.loadBalancer?.ingress?.map((i) => i.hostname || i.ip || '-'),
-        );
+        return ServiceIPsRow({
+          name: t('External load balancer'),
+          desc: t('Ingress points of load balancer'),
+          ips: service?.status?.loadBalancer?.ingress?.map((i) => i.hostname || i.ip || '-'),
+        });
       case 'ExternalName':
-        return ServiceIPsRow(
-          t('External service name'),
-          t('Location of the resource that backs the service'),
-          [service?.spec?.externalName],
-        );
+        return ServiceIPsRow({
+          name: t('External service name'),
+          desc: t('Location of the resource that backs the service'),
+          ips: [service?.spec?.externalName],
+        });
       default:
-        return ServiceIPsRow(t('Cluster IP'), t('Accessible within the cluster only'), [
-          service?.spec?.clusterIP,
-        ]);
+        return ServiceIPsRow({ 
+          name: t('Cluster IP'), 
+          desc: t('Accessible within the cluster only'),
+          ips: [ service?.spec?.clusterIP, ]
+        });
     }
   };
 
@@ -58,14 +46,33 @@ const ServiceAddress: FC<{ service: IoK8sApiCoreV1Service }> = ({ service }) => 
       <div className="rows">
         {ServiceType(service.spec.type)}
         {service.spec.externalIPs &&
-          ServiceIPsRow(
-            t('External IP'),
-            t('IP Addresses accepting traffic for service'),
-            service?.spec?.externalIPs,
-          )}
+          ServiceIPsRow({
+            name: t('External IP'),
+            desc: t('IP Addresses accepting traffic for service'),
+            ips: service?.spec?.externalIPs,
+          })}
       </div>
     </div>
   );
+};
+
+const ServiceIPsRow: FC<{ name:string, desc:string, ips: string[], note?:string }> = ({ name, desc, ips, note = null} ) => {
+  const { t } = useNetworkingTranslation();
+
+  return (
+    <div className="co-ip-row">
+      <div className="row">
+        <div className="col-xs-6">
+          <p className="ip-name">{name}</p>
+          <p className="ip-desc">{desc}</p>
+        </div>
+        <div className="col-xs-6">
+          {note && <MutedText content={note} isSpan />}
+          {ips ? ips.join(', '): t('Pending')}
+        </div>
+      </div>
+    </div>
+  )
 };
 
 export default ServiceAddress;


### PR DESCRIPTION
Services in pending state had no ips assigned, which resulted to a crash when a ServiceIPsRow component tried to read those undefined ips. Conditional unwrap of the ips fixed this issue. Restructed the component ServiceAddress.

Before:

https://github.com/user-attachments/assets/78a5c98e-d2f8-4784-9088-72ef4d9475cb

After:

https://github.com/user-attachments/assets/243661e8-8481-41c0-858e-0f3aaadef154

