### PR TITLE
OCPBUGS-46553: fix ports as number instead of strings

### DIFF
--- a/src/views/networkpolicies/new/components/NetworkPolicyFormPorts.tsx
+++ b/src/views/networkpolicies/new/components/NetworkPolicyFormPorts.tsx
@@ -5,7 +5,7 @@ import { Button } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/minus-circle-icon';
 import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
-import { NetworkPolicyPort } from '@utils/models';
+import { convertPort, NetworkPolicyPort } from '@utils/models';
 
 import PortsDropdown from '../NetworkPolicyPortsDropdown';
 
@@ -49,7 +49,13 @@ const NetworkPolicyPorts: FC<NetworkPolicyPortsProps> = (props) => {
                   id={`${key}-port`}
                   name={`${key}-port`}
                   onChange={(event) =>
-                    onSingleChange({ ...port, port: event.currentTarget.value }, idx)
+                    onSingleChange(
+                      {
+                        ...port,
+                        port: convertPort(event.currentTarget.value),
+                      },
+                      idx,
+                    )
                   }
                   placeholder="443"
                   value={port.port}


### PR DESCRIPTION
Ports can be a name or number. The name should be alphanumeric and with at least an a-z character.
If it's a number, we should parse it.


**Before**

<img width="1221" alt="Screenshot 2024-12-20 at 12 06 34" src="https://github.com/user-attachments/assets/d1af091c-b4a5-4e0f-bb9c-ea1214ce039a" />



**After**


<img width="1221" alt="Screenshot 2024-12-20 at 12 03 48" src="https://github.com/user-attachments/assets/90e0cbb6-41a9-4142-89f2-aa8875bdbcaa" />
