### PR TITLE
OCPBUGS-46557: fix project displayName and description

### DIFF
--- a/src/views/createprojectmodal/components/DetailsProjectTab.tsx
+++ b/src/views/createprojectmodal/components/DetailsProjectTab.tsx
@@ -4,26 +4,13 @@ import { useFormContext } from 'react-hook-form';
 import { FormGroup, TextArea, TextInput } from '@patternfly/react-core';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 
-import { DESCRIPTION_ANNOTATION, DISPLAY_NAME_ANNOTATION } from '../constants';
 import { CreateProjectModalFormState } from '../types';
 
 import ProjectNamePopover from './ProjectNamePopover';
 
 const DetailsProjectTab: FC = ({}) => {
   const { t } = useNetworkingTranslation();
-  const { register, setValue, watch } = useFormContext<CreateProjectModalFormState>();
-
-  const annotations = watch('project.metadata.annotations');
-
-  const description = annotations[DESCRIPTION_ANNOTATION];
-  const displayName = annotations[DISPLAY_NAME_ANNOTATION];
-
-  const changeAnnotations = (newDescription: string, newDisplayName: string) => {
-    setValue('project.metadata.annotations', {
-      [DESCRIPTION_ANNOTATION]: newDescription,
-      [DISPLAY_NAME_ANNOTATION]: newDisplayName,
-    });
-  };
+  const { register, setValue } = useFormContext<CreateProjectModalFormState>();
 
   return (
     <>
@@ -50,18 +37,12 @@ const DetailsProjectTab: FC = ({}) => {
         <TextInput
           id="input-display-name"
           name="displayName"
-          onChange={(_, newValue) => changeAnnotations(description, newValue)}
+          {...register('project.displayName')}
           type="text"
-          value={displayName}
         />
       </FormGroup>
       <FormGroup fieldId="input-description" label={t('Description')}>
-        <TextArea
-          id="input-description"
-          name="description"
-          onChange={(_, newValue) => changeAnnotations(newValue, displayName)}
-          value={description}
-        />
+        <TextArea id="input-description" name="description" {...register('project.description')} />
       </FormGroup>
     </>
   );

--- a/src/views/createprojectmodal/constants.ts
+++ b/src/views/createprojectmodal/constants.ts
@@ -16,11 +16,9 @@ export const networkTypeLabels = {
 export const initialFormState: CreateProjectModalFormState = {
   networkType: NETWORK_TYPE.POD_NETWORK,
   project: {
+    description: '',
+    displayName: '',
     metadata: {
-      annotations: {
-        [DESCRIPTION_ANNOTATION]: null,
-        [DISPLAY_NAME_ANNOTATION]: null,
-      },
       name: '',
     },
   },

--- a/src/views/createprojectmodal/types.ts
+++ b/src/views/createprojectmodal/types.ts
@@ -1,8 +1,6 @@
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { ClusterUserDefinedNetworkKind, UserDefinedNetworkKind } from '@utils/resources/udns/types';
 
-import { DESCRIPTION_ANNOTATION, DISPLAY_NAME_ANNOTATION } from './constants';
-
 export enum NETWORK_TYPE {
   POD_NETWORK,
   UDN,
@@ -13,8 +11,10 @@ export type CreateProjectModalFormState = {
   clusterUDN?: ClusterUserDefinedNetworkKind;
   networkType: NETWORK_TYPE;
   project: K8sResourceCommon & {
+    description: string;
+    displayName: string;
     metadata: {
-      annotations: { [DESCRIPTION_ANNOTATION]: string; [DISPLAY_NAME_ANNOTATION]: string };
+      name: string;
     };
   };
   udn: UserDefinedNetworkKind;


### PR DESCRIPTION
the create project request is differently represented respect to the project created.

The create project request wants:
```{ 
  metadata: {
    name
  }, 
  displayName, 
  description 
}
```

<img width="1232" alt="Screenshot 2024-12-20 at 12 44 37" src="https://github.com/user-attachments/assets/be0f08b1-3d5f-4243-ae51-494a3eb28532" />
<img width="1232" alt="Screenshot 2024-12-20 at 12 44 43" src="https://github.com/user-attachments/assets/79e3d911-54c2-4e9f-b1d4-f9e31eca2c52" />
