### PR TITLE
CNV-54828: fix udn create button

### DIFF
--- a/src/utils/resources/udns/helper.ts
+++ b/src/utils/resources/udns/helper.ts
@@ -1,0 +1,9 @@
+import {
+  ClusterUserDefinedNetworkKind,
+  UserDefinedNetworkKind,
+  UserDefinedNetworkRole,
+} from './types';
+
+export const isPrimaryUDN = (udn: ClusterUserDefinedNetworkKind | UserDefinedNetworkKind) =>
+  udn?.spec?.layer2?.role === UserDefinedNetworkRole.Primary ||
+  udn?.spec?.network?.layer2?.role === UserDefinedNetworkRole.Primary;

--- a/src/views/udns/list/UserDefinedNetworksList.tsx
+++ b/src/views/udns/list/UserDefinedNetworksList.tsx
@@ -2,7 +2,6 @@ import React, { FC } from 'react';
 
 import {
   ListPageBody,
-  ListPageCreateDropdown,
   ListPageFilter,
   ListPageHeader,
   useK8sWatchResources,
@@ -19,6 +18,7 @@ import {
 } from '@utils/models';
 import { ClusterUserDefinedNetworkKind, UserDefinedNetworkKind } from '@utils/resources/udns/types';
 
+import UDNListCreateButton from './components/UDNListCreateButton';
 import UserDefinedNetworkCreateModal from './components/UserDefinedNetworkCreateModal';
 import UserDefinedNetworkRow from './components/UserDefinedNetworkRow';
 import useUDNColumns from './hooks/useUDNColumns';
@@ -73,23 +73,7 @@ const UserDefinedNetworksList: FC<UserDefinedNetworksListProps> = ({ namespace }
       title={title}
     >
       <ListPageHeader title={title}>
-        <ListPageCreateDropdown
-          createAccessReview={{
-            groupVersionKind: UserDefinedNetworkModelGroupVersionKind,
-            namespace,
-          }}
-          items={{
-            ClusterUserDefinedNetwork: t('ClusterUserDefinedNetwork'),
-            UserDefinedNetwork: t('UserDefinedNetwork'),
-          }}
-          onClick={(item) =>
-            createModal(UserDefinedNetworkCreateModal, {
-              isClusterUDN: item === 'ClusterUserDefinedNetwork',
-            })
-          }
-        >
-          {t('Create')}
-        </ListPageCreateDropdown>
+        <UDNListCreateButton allUDNs={allResources} namespace={namespace} />
       </ListPageHeader>
       <ListPageBody>
         <ListPageFilter

--- a/src/views/udns/list/components/UDNListCreateButton.tsx
+++ b/src/views/udns/list/components/UDNListCreateButton.tsx
@@ -1,0 +1,76 @@
+import React, { FC } from 'react';
+
+import {
+  ListPageCreateButton,
+  ListPageCreateDropdown,
+  useModal,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
+import {
+  ClusterUserDefinedNetworkModelGroupVersionKind,
+  UserDefinedNetworkModel,
+  UserDefinedNetworkModelGroupVersionKind,
+} from '@utils/models';
+import { getNamespace } from '@utils/resources/shared';
+import { isPrimaryUDN } from '@utils/resources/udns/helper';
+import { ClusterUserDefinedNetworkKind, UserDefinedNetworkKind } from '@utils/resources/udns/types';
+
+import UserDefinedNetworkCreateModal from './UserDefinedNetworkCreateModal';
+
+type UDNListCreateButtonProps = {
+  allUDNs: Array<ClusterUserDefinedNetworkKind | UserDefinedNetworkKind>;
+  namespace: string;
+};
+
+const UDNListCreateButton: FC<UDNListCreateButtonProps> = ({ allUDNs, namespace }) => {
+  const { t } = useNetworkingTranslation();
+  const createModal = useModal();
+
+  const namespaceHavePrimaryUDN = allUDNs?.find(
+    (udn) =>
+      udn.kind === UserDefinedNetworkModel.kind &&
+      getNamespace(udn) === namespace &&
+      isPrimaryUDN(udn),
+  );
+
+  if (namespaceHavePrimaryUDN) {
+    return (
+      <ListPageCreateButton
+        className="list-page-create-button-margin"
+        createAccessReview={{
+          groupVersionKind: ClusterUserDefinedNetworkModelGroupVersionKind,
+          namespace,
+        }}
+        onClick={() =>
+          createModal(UserDefinedNetworkCreateModal, {
+            isClusterUDN: true,
+          })
+        }
+      >
+        {t('Create ClusterUserDefinedNetwork')}
+      </ListPageCreateButton>
+    );
+  }
+
+  return (
+    <ListPageCreateDropdown
+      createAccessReview={{
+        groupVersionKind: UserDefinedNetworkModelGroupVersionKind,
+        namespace,
+      }}
+      items={{
+        ClusterUserDefinedNetwork: t('ClusterUserDefinedNetwork'),
+        UserDefinedNetwork: t('UserDefinedNetwork'),
+      }}
+      onClick={(item) =>
+        createModal(UserDefinedNetworkCreateModal, {
+          isClusterUDN: item === 'ClusterUserDefinedNetwork',
+        })
+      }
+    >
+      {t('Create')}
+    </ListPageCreateDropdown>
+  );
+};
+
+export default UDNListCreateButton;


### PR DESCRIPTION
The udn create modal creates only primary udns and you should not be able to create multiple primary udns for one namespace. If you select a namespace, do not let the user create a namespace primary udn if one already exists

<img width="1904" alt="Screenshot 2025-01-22 at 15 50 32" src="https://github.com/user-attachments/assets/456b34d1-b3c7-4c5f-b86f-1f7f84b19840" />
<img width="1904" alt="Screenshot 2025-01-22 at 15 50 36" src="https://github.com/user-attachments/assets/a559af40-82b2-4a5e-81c9-4e04b72d9562" />
