### PR TITLE
CNV-55234: do not show all namesapces in cudn namespace column

### DIFF
--- a/locales/en/plugin__networking-console-plugin.json
+++ b/locales/en/plugin__networking-console-plugin.json
@@ -36,7 +36,6 @@
   "Add ports to restrict traffic through them. If no ports are provided, your policy will make all ports accessible to traffic.": "Add ports to restrict traffic through them. If no ports are provided, your policy will make all ports accessible to traffic.",
   "Add subnet": "Add subnet",
   "All incoming traffic is denied to Pods in {{namespace}}": "All incoming traffic is denied to Pods in {{namespace}}",
-  "All namespaces": "All namespaces",
   "All outgoing traffic is allowed by default. Egress rules can be used to restrict outgoing traffic if the cluster network provider allows it. When using the OpenShift SDN cluster network provider, egress network policy is not supported.": "All outgoing traffic is allowed by default. Egress rules can be used to restrict outgoing traffic if the cluster network provider allows it. When using the OpenShift SDN cluster network provider, egress network policy is not supported.",
   "All outgoing traffic is denied from Pods in {{namespace}}": "All outgoing traffic is denied from Pods in {{namespace}}",
   "All pods within {{namespace}}": "All pods within {{namespace}}",

--- a/src/utils/utils/constants.ts
+++ b/src/utils/utils/constants.ts
@@ -1,0 +1,1 @@
+export const NO_DATA_DASH = '-';

--- a/src/views/udns/list/components/UserDefinedNetworkRow.tsx
+++ b/src/views/udns/list/components/UserDefinedNetworkRow.tsx
@@ -13,6 +13,7 @@ import { UserDefinedNetworkModel } from '@utils/models';
 import { getName, getNamespace } from '@utils/resources/shared';
 import { getModel, getTopology } from '@utils/resources/udns/selectors';
 import { ClusterUserDefinedNetworkKind, UserDefinedNetworkKind } from '@utils/resources/udns/types';
+import { NO_DATA_DASH } from '@utils/utils/constants';
 import UDNActions from '@views/udns/actions/UDNActions';
 
 type UserDefinedNetworkRowType = RowProps<ClusterUserDefinedNetworkKind | UserDefinedNetworkKind>;
@@ -40,7 +41,7 @@ const UserDefinedNetworkRow: FC<UserDefinedNetworkRowType> = ({ activeColumnIDs,
             name={namespace}
           />
         ) : (
-          t('All namespaces')
+          NO_DATA_DASH
         )}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="topology">


### PR DESCRIPTION
Seems like the cudn works on all the namespaces.

At least take the namespace column empty at this point so there is no confusion about the resource namespace and the namespace that cudn manage

**Before**

<img width="1904" alt="Screenshot 2025-01-24 at 12 13 49" src="https://github.com/user-attachments/assets/e6eca6b2-381b-4c31-b386-ee3d1ad3b31a" />



**After**

<img width="1904" alt="Screenshot 2025-01-24 at 12 13 12" src="https://github.com/user-attachments/assets/4366dc01-4d4b-4bd1-a55b-0b30558a14a8" />
