### PR TITLE
CNV-55457: Remove project modal

### DIFF
--- a/plugin-manifest.ts
+++ b/plugin-manifest.ts
@@ -2,10 +2,6 @@ import { EncodedExtension } from '@openshift/dynamic-plugin-sdk-webpack';
 import { ConsolePluginBuildMetadata } from '@openshift-console/dynamic-plugin-sdk-webpack/lib/build-types';
 
 import { FlagsExposedModules, FlagsExtensions } from './src/utils/flags/manifest';
-import {
-  CreateProjectModalExposedModules,
-  CreateProjectModalExtensions,
-} from './src/views/createprojectmodal/manifest';
 import { IngressesExposedModules, IngressesExtensions } from './src/views/ingresses/manifest';
 import { NADsExposedModules, NADsExtensions } from './src/views/nads/manifest';
 import {
@@ -33,7 +29,6 @@ export const pluginMetadata: ConsolePluginBuildMetadata = {
     ...FlagsExposedModules,
     ...RoutesExposedModules,
     ...UserDefinedNetworksExposedModules,
-    ...CreateProjectModalExposedModules,
     yamlTemplates: './templates/index.ts',
   },
   name: 'networking-console-plugin',
@@ -48,5 +43,4 @@ export const extensions: EncodedExtension[] = [
   ...NADsExtensions,
   ...FlagsExtensions,
   ...UserDefinedNetworksExtensions,
-  ...CreateProjectModalExtensions,
 ];


### PR DESCRIPTION
Removing the custom project modal with udn creation flow as networking team found some issues with that. 

They have to implement a mechanism to create project with primary udn with just one HTTP request. 

Having to do two requests ( one for creating the project and one for creating the udn) is having some issues. 

This issue is not UI related as the same thing happens with cli 

**What people will see after this**



<img width="826" alt="Screenshot 2025-01-28 at 16 43 46" src="https://github.com/user-attachments/assets/53f738c9-fe98-4eb6-9c16-330585f0c0d2" />
