### PR TITLE
OCPBUGS-45803: Fix weight width

### DIFF
--- a/src/views/routes/form/AlternateService.tsx
+++ b/src/views/routes/form/AlternateService.tsx
@@ -99,6 +99,7 @@ const AlternateService: FC<AlternateServiceProps> = ({
             </FormGroupHelperText>
           </FormGroup>
           <FormGroup
+            className="networking-route-form__service-weight-input"
             fieldId={`${AS_WEIGHT_PREFIX_FIELD_ID}${field.id}`}
             isRequired
             label={t('Alternate Service weight')}

--- a/src/views/routes/form/RouteFormPage.tsx
+++ b/src/views/routes/form/RouteFormPage.tsx
@@ -20,6 +20,8 @@ import { LAST_VIEWED_EDITOR_TYPE_USERSETTING_KEY } from '@views/networkpolicies/
 import RouteForm from './RouteForm';
 import { generateDefaultRoute } from './utils';
 
+import './networking-route-form.scss';
+
 type RouteFormPageProps = { initialRoute?: RouteKind };
 
 const RouteFormPage: FC<RouteFormPageProps> = ({ initialRoute }) => {
@@ -32,7 +34,7 @@ const RouteFormPage: FC<RouteFormPageProps> = ({ initialRoute }) => {
 
   return (
     <>
-      <PageSection variant={PageSectionVariants.light}>
+      <PageSection className="networking-route-form" variant={PageSectionVariants.light}>
         <Title headingLevel="h2">
           {initialRoute
             ? t('Edit {{label}}', { label: RouteModel.label })

--- a/src/views/routes/form/ServiceSelector.tsx
+++ b/src/views/routes/form/ServiceSelector.tsx
@@ -109,7 +109,11 @@ const ServiceSelector: FC<ServiceSelectorProps> = ({ namespace }) => {
                 {t('Service to route to.')}
               </FormGroupHelperText>
             </FormGroup>
-            <FormGroup fieldId={SERVICE_WEIGHT_FIELD_ID} label={t('Service weight')}>
+            <FormGroup
+              className="networking-route-form__service-weight-input"
+              fieldId={SERVICE_WEIGHT_FIELD_ID}
+              label={t('Service weight')}
+            >
               <TextInput
                 defaultValue={DEFAULT_SERVICE_WEIGHT}
                 id={SERVICE_WEIGHT_FIELD_ID}

--- a/src/views/routes/form/networking-route-form.scss
+++ b/src/views/routes/form/networking-route-form.scss
@@ -1,0 +1,9 @@
+.networking-route-form {
+  &__service-weight-input {
+    max-width: 300px;
+
+    .pf-v5-c-form-control {
+      max-width: 100px;
+    }
+  }
+}


### PR DESCRIPTION
Service weight is a number input between 0 and 255 so there is no reason should be so big


**Before**

<img width="1623" alt="Screenshot 2025-01-29 at 10 58 12" src="https://github.com/user-attachments/assets/68150410-a564-4703-a93d-407e31312b74" />


**After**

<img width="826" alt="Screenshot 2025-01-29 at 10 53 53" src="https://github.com/user-attachments/assets/097c4ac1-bcb3-4770-a8b4-e3d59b6614c3" />
<img width="826" alt="Screenshot 2025-01-29 at 10 56 57" src="https://github.com/user-attachments/assets/21059531-dfbc-477c-a326-60eff9e4150f" />
