### PR TITLE
Fix nads with no label

### DIFF
--- a/src/utils/resources/nads/helpers.ts
+++ b/src/utils/resources/nads/helpers.ts
@@ -2,4 +2,4 @@ import { UDN_LABEL } from './constants';
 import { NetworkAttachmentDefinitionKind } from './types';
 
 export const isUserDefinedNetworkNAD = (nad: NetworkAttachmentDefinitionKind) =>
-  Object.keys(nad?.metadata?.labels).includes(UDN_LABEL);
+  Object.keys(nad?.metadata?.labels || {})?.includes(UDN_LABEL);


### PR DESCRIPTION
Nad with no label is crashing the nad list as `Object.keys` throw an exception when the input is undefined