### PR TITLE
OCPBUGS-42135: Update documentation links

### DIFF
--- a/src/utils/constants/documentation.tsx
+++ b/src/utils/constants/documentation.tsx
@@ -24,6 +24,9 @@ export const DOC_URL_STORAGE_CLASSES_SCALEIO = `${KUBE_DOCS}/concepts/storage/st
 export const DOC_URL_STORAGE_CLASSES_STORAGEOS = `${KUBE_DOCS}/concepts/storage/storage-classes/#storageos`;
 export const DOC_URL_STORAGE_CLASSES_VSPHERE = `${KUBE_DOCS}/concepts/storage/storage-classes/#vsphere`;
 
+export const DOC_URL_NETWORK_SERVICE = `${KUBE_DOCS}/concepts/services-networking/service/`;
+export const DOC_URL_NETWORK_INGRESS = `${KUBE_DOCS}/concepts/services-networking/ingress/`;
+
 export const documentationURLs: documentationURLsType = {
   applicationHealth: {
     downstream: 'html/building_applications/application-health',
@@ -38,6 +41,10 @@ export const documentationURLs: documentationURLsType = {
   deprecatedDeploymentConfig: {
     downstream: 'html/building_applications/deployments',
     upstream: 'applications/deployments/what-deployments-are.html',
+  },
+  multipleNetworks: {
+    downstream: 'html/networking/multiple-networks',
+    upstream: 'networking/multiple_networks/understanding-multiple-networks.html',
   },
   networkPolicy: {
     downstream: 'html/networking/network-policy#about-network-policy',
@@ -55,6 +62,10 @@ export const documentationURLs: documentationURLsType = {
   postInstallationMachineConfigurationTasks: {
     downstream: 'html/post-installation_configuration/index',
     upstream: 'post_installation_configuration/machine-configuration-tasks.html',
+  },
+  routes: {
+    downstream: 'html/networking/configuring-routes',
+    upstream: 'networking/routes/route-configuration.html',
   },
   understandingUpgradeChannels: {
     downstream:

--- a/src/views/ingresses/list/IngressesList.tsx
+++ b/src/views/ingresses/list/IngressesList.tsx
@@ -14,6 +14,7 @@ import {
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
 import ListEmptyState from '@utils/components/ListEmptyState/ListEmptyState';
+import { DOC_URL_NETWORK_INGRESS } from '@utils/constants/documentation';
 import { SHARED_DEFAULT_PATH_NEW_RESOURCE_YAML } from '@utils/constants/ui';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { getResourceURL } from '@utils/resources/shared';
@@ -47,7 +48,7 @@ const IngressesList: FC<IngressesListProps> = ({ namespace }) => {
       data={data}
       error={loadError}
       kind={IngressModel.kind}
-      learnMoreLink="https://kubernetes.io/docs/concepts/services-networking/ingress/"
+      learnMoreLink={DOC_URL_NETWORK_INGRESS}
       loaded={loaded}
       title={title}
     >

--- a/src/views/nads/list/NetworkAttachmentDefinitionList.tsx
+++ b/src/views/nads/list/NetworkAttachmentDefinitionList.tsx
@@ -15,6 +15,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import ListEmptyState from '@utils/components/ListEmptyState/ListEmptyState';
 import { DEFAULT_NAMESPACE } from '@utils/constants';
+import { documentationURLs, getDocumentationURL } from '@utils/constants/documentation';
 import { SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM } from '@utils/constants/ui';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { NetworkAttachmentDefinitionKind } from '@utils/resources/nads/types';
@@ -50,7 +51,7 @@ const NetworkAttachmentDefinitionList: FC<NetworkAttachmentDefinitionListProps> 
       data={data}
       error={loadError}
       kind={NetworkAttachmentDefinitionModel.kind}
-      learnMoreLink="https://docs.openshift.com/container-platform/4.16/networking/multiple_networks/configuring-multi-network-policy.html"
+      learnMoreLink={getDocumentationURL(documentationURLs.multipleNetworks)}
       loaded={loaded}
       title={title}
     >

--- a/src/views/networkpolicies/list/MultiNetworkPolicyList.tsx
+++ b/src/views/networkpolicies/list/MultiNetworkPolicyList.tsx
@@ -11,6 +11,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { Pagination } from '@patternfly/react-core';
 import ListEmptyState from '@utils/components/ListEmptyState/ListEmptyState';
+import { documentationURLs, getDocumentationURL } from '@utils/constants/documentation';
 import { SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM } from '@utils/constants/ui';
 import usePagination from '@utils/hooks/usePagination/usePagination';
 import { paginationDefaultValues } from '@utils/hooks/usePagination/utils/constants';
@@ -47,7 +48,7 @@ const MultiNetworkPolicyList: FC<MultiNetworkPolicyListProps> = ({ namespace }) 
       data={data}
       error={loadError}
       kind={MultiNetworkPolicyModel.kind}
-      learnMoreLink="https://docs.openshift.com/container-platform/4.16/networking/multiple_networks/configuring-multi-network-policy.html"
+      learnMoreLink={getDocumentationURL(documentationURLs.multipleNetworks)}
       loaded={loaded}
     >
       <ListPageBody>

--- a/src/views/networkpolicies/list/NetworkPolicyList.tsx
+++ b/src/views/networkpolicies/list/NetworkPolicyList.tsx
@@ -5,12 +5,15 @@ import { IoK8sApiNetworkingV1NetworkPolicy } from '@kubevirt-ui/kubevirt-api/kub
 import {
   ListPageBody,
   ListPageFilter,
+  useFlag,
   useK8sWatchResource,
   useListPageFilter,
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { Pagination } from '@patternfly/react-core';
 import ListEmptyState from '@utils/components/ListEmptyState/ListEmptyState';
+import { FLAGS } from '@utils/constants';
+import { getNetworkPolicyDocURL } from '@utils/constants/documentation';
 import { SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM } from '@utils/constants/ui';
 import usePagination from '@utils/hooks/usePagination/usePagination';
 import { paginationDefaultValues } from '@utils/hooks/usePagination/utils/constants';
@@ -38,6 +41,7 @@ const NetworkPolicyList: FC<NetworkPolicyListProps> = ({ namespace }) => {
   const { onPaginationChange, pagination } = usePagination();
   const [data, filteredData, onFilterChange] = useListPageFilter(networkPolicies);
   const [columns, activeColumns] = useNetworkPolicyColumn(pagination, filteredData);
+  const hasOpenshiftFlag = useFlag(FLAGS.OPENSHIFT);
 
   return (
     <ListEmptyState<IoK8sApiNetworkingV1NetworkPolicy>
@@ -45,7 +49,7 @@ const NetworkPolicyList: FC<NetworkPolicyListProps> = ({ namespace }) => {
       data={data}
       error={loadError}
       kind={NetworkPolicyModel.kind}
-      learnMoreLink="https://kubernetes.io/docs/concepts/services-networking/network-policies/"
+      learnMoreLink={getNetworkPolicyDocURL(hasOpenshiftFlag)}
       loaded={loaded}
     >
       <ListPageBody>

--- a/src/views/routes/list/RoutesList.tsx
+++ b/src/views/routes/list/RoutesList.tsx
@@ -13,6 +13,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import ListEmptyState from '@utils/components/ListEmptyState/ListEmptyState';
 import { DEFAULT_NAMESPACE } from '@utils/constants';
+import { documentationURLs, getDocumentationURL } from '@utils/constants/documentation';
 import { SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM } from '@utils/constants/ui';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { resourcePathFromModel } from '@utils/resources/shared';
@@ -47,7 +48,7 @@ const RoutesList: FC<RoutesListProps> = ({ namespace }) => {
       data={routesFetch}
       error={loadError}
       kind={RouteModel.kind}
-      learnMoreLink="https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/networking/configuring-routes"
+      learnMoreLink={getDocumentationURL(documentationURLs.routes)}
       loaded={loaded}
       title={title}
     >

--- a/src/views/services/list/ServiceList.tsx
+++ b/src/views/services/list/ServiceList.tsx
@@ -14,6 +14,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import ListEmptyState from '@utils/components/ListEmptyState/ListEmptyState';
 import { DEFAULT_NAMESPACE } from '@utils/constants';
+import { DOC_URL_NETWORK_SERVICE } from '@utils/constants/documentation';
 import {
   SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM,
   SHARED_DEFAULT_PATH_NEW_RESOURCE_YAML,
@@ -49,7 +50,7 @@ const ServiceList: FC<ServiceListProps> = ({ namespace }) => {
       data={data}
       error={loadError}
       kind={ServiceModel.kind}
-      learnMoreLink="https://kubernetes.io/docs/concepts/services-networking/service/"
+      learnMoreLink={DOC_URL_NETWORK_SERVICE}
       loaded={loaded}
       title={title}
     >

--- a/src/views/udns/list/UserDefinedNetworksList.tsx
+++ b/src/views/udns/list/UserDefinedNetworksList.tsx
@@ -10,6 +10,7 @@ import {
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
 import ListEmptyState from '@utils/components/ListEmptyState/ListEmptyState';
+import { documentationURLs, getDocumentationURL } from '@utils/constants/documentation';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import {
   ClusterUserDefinedNetworkModelGroupVersionKind,
@@ -68,7 +69,7 @@ const UserDefinedNetworksList: FC<UserDefinedNetworksListProps> = ({ namespace }
       data={data}
       error={loadError}
       kind={UserDefinedNetworkModel.kind}
-      learnMoreLink="https://docs.openshift.com/container-platform/4.17/networking/multiple_networks/understanding-user-defined-network.html"
+      learnMoreLink={getDocumentationURL(documentationURLs.multipleNetworks)}
       loaded={loaded}
       onCreate={() => createModal(UserDefinedNetworkCreateModal, {})}
       title={title}


### PR DESCRIPTION
1. consolidate documentation links in one file
2. provide links for routes and multiple networks with
   upstream/downstream switching
3. provide static k8s links to network services and ingress
