### PR TITLE
OCPBUGS-41964: No default path in the route creation form

### DIFF
--- a/src/views/routes/form/utils.ts
+++ b/src/views/routes/form/utils.ts
@@ -12,7 +12,6 @@ export const generateDefaultRoute = (namespace: string): RouteKind => ({
     namespace,
   },
   spec: {
-    path: '/',
     to: {
       kind: 'Service',
       name: '',


### PR DESCRIPTION
Do not use a default path. IT's not a required parameter to create route