### PR TITLE
CNV-56236: fix cudn modal form titles

### DIFF
--- a/src/views/udns/list/components/ClusterUDNNamespaceSelector.tsx
+++ b/src/views/udns/list/components/ClusterUDNNamespaceSelector.tsx
@@ -2,7 +2,7 @@ import React, { FC, MouseEvent, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { ResourceIcon } from '@openshift-console/dynamic-plugin-sdk';
-import { ExpandableSection, FormGroup, List, ListItem } from '@patternfly/react-core';
+import { ExpandableSection, FormSection, List, ListItem } from '@patternfly/react-core';
 import MatchLabels from '@utils/components/MatchLabels/MatchLabels';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { getName } from '@utils/resources/shared';
@@ -31,7 +31,7 @@ const ClusterUDNNamespaceSelector: FC = () => {
   const matchingProjects = projects?.filter((project) => match(project, matchLabels));
 
   return (
-    <FormGroup fieldId="cluster-udn-projects" isRequired label={t('Project(s)')}>
+    <FormSection title={t('Project(s)')} titleElement="h2">
       <MatchLabels
         matchLabels={matchLabels}
         onChange={(newMatchLabels) =>
@@ -54,7 +54,7 @@ const ClusterUDNNamespaceSelector: FC = () => {
           {matchingProjects.length === 0 && t('No matching projects')}
         </List>
       </ExpandableSection>
-    </FormGroup>
+    </FormSection>
   );
 };
 


### PR DESCRIPTION
We had two FormGroup components nested. Now we have FormSection (Projects label) with FormGroup inside (match labels)


**Before**

<img width="1920" alt="Screenshot 2025-02-11 at 16 32 43" src="https://github.com/user-attachments/assets/76732347-af2d-4a80-9309-4c2fed6baf42" />




**After**

<img width="1920" alt="Screenshot 2025-02-11 at 16 30 31" src="https://github.com/user-attachments/assets/19d98c74-8d67-4fc3-aeae-16a445715276" />
