### PR TITLE
CNV-59853: remove co-m-table-grid and dropdown-kebab-pf classes

### DIFF
--- a/src/views/ingresses/details/tabs/details/components/IngressRulesSection/IngressRulesSection.tsx
+++ b/src/views/ingresses/details/tabs/details/components/IngressRulesSection/IngressRulesSection.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 
 import { IoK8sApiNetworkingV1Ingress } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
+import { Table } from '@patternfly/react-table';
 import Title from '@utils/components/Title/Title';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { getNamespace } from '@utils/resources/shared';
@@ -22,10 +23,10 @@ const IngressRulesSection: FC<IngressRulesSectionProps> = ({ ingress }) => {
           'These rules are handled by a routing layer (Ingress Controller) which is updated as the rules are modified. The Ingress controller implementation defines how headers and other metadata are forwarded or manipulated',
         )}
       </p>
-      <div className="co-m-table-grid co-m-table-grid--bordered">
+      <Table gridBreakPoint="">
         <RulesHeader />
         <RulesRows namespace={getNamespace(ingress)} spec={ingress?.spec} />
-      </div>
+      </Table>
     </>
   );
 };

--- a/src/views/ingresses/details/tabs/details/components/IngressRulesSection/RulesHeader.tsx
+++ b/src/views/ingresses/details/tabs/details/components/IngressRulesSection/RulesHeader.tsx
@@ -1,18 +1,21 @@
 import React, { FC } from 'react';
 
+import { Th, Thead, Tr } from '@patternfly/react-table';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 
 const RulesHeader: FC = ({}) => {
   const { t } = useNetworkingTranslation();
 
   return (
-    <div className="row co-m-table-grid__head">
-      <div className="col-xs-6 col-sm-4 col-md-2">{t('Host')}</div>
-      <div className="col-xs-6 col-sm-4 col-md-2">{t('Path')}</div>
-      <div className="col-md-3 hidden-sm hidden-xs">{t('Path type')}</div>
-      <div className="col-sm-4 col-md-2 hidden-xs">{t('Service')}</div>
-      <div className="col-md-2 hidden-sm hidden-xs">{t('Service port')}</div>
-    </div>
+    <Thead>
+      <Tr>
+        <Th>{t('Host')}</Th>
+        <Th>{t('Path')}</Th>
+        <Th visibility={['hidden', 'visibleOnMd']}>{t('Path type')}</Th>
+        <Th visibility={['hidden', 'visibleOnSm']}>{t('Service')}</Th>
+        <Th visibility={['hidden', 'visibleOnMd']}>{t('Service port')}</Th>
+      </Tr>
+    </Thead>
   );
 };
 

--- a/src/views/ingresses/details/tabs/details/components/IngressRulesSection/RulesRow.tsx
+++ b/src/views/ingresses/details/tabs/details/components/IngressRulesSection/RulesRow.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 
 import { ServiceModel } from '@kubevirt-ui/kubevirt-api/console';
 import { getGroupVersionKindForModel, ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
+import { Td, Tr } from '@patternfly/react-table';
 import { IngressPathRule } from '@views/ingresses/details/tabs/details/utils/types';
 
 type RulesRowProps = {
@@ -11,17 +12,13 @@ type RulesRowProps = {
 
 const RulesRow: FC<RulesRowProps> = ({ namespace, rule }) => {
   return (
-    <div className="row co-resource-list__item">
-      <div className="col-xs-6 col-sm-4 col-md-2 co-break-word">
-        <div>{rule?.host}</div>
-      </div>
-      <div className="col-xs-6 col-sm-4 col-md-2 co-break-word">
-        <div>{rule?.path}</div>
-      </div>
-      <div className="col-md-3 hidden-sm hidden-xs co-break-word">
-        <div>{rule?.pathType}</div>
-      </div>
-      <div className="col-sm-4 col-md-2 hidden-xs">
+    <Tr>
+      <Td className="co-break-word">{rule?.host}</Td>
+      <Td className="co-break-word">{rule?.path}</Td>
+      <Td className="co-break-word" visibility={['hidden', 'visibleOnMd']}>
+        {rule?.pathType}
+      </Td>
+      <Td visibility={['hidden', 'visibleOnSm']}>
         {rule?.serviceName ? (
           <ResourceLink
             groupVersionKind={getGroupVersionKindForModel(ServiceModel)}
@@ -31,11 +28,9 @@ const RulesRow: FC<RulesRowProps> = ({ namespace, rule }) => {
         ) : (
           '-'
         )}
-      </div>
-      <div className="col-xs-2 hidden-sm hidden-xs">
-        <div>{rule?.servicePort || '-'}</div>
-      </div>
-    </div>
+      </Td>
+      <Td visibility={['hidden', 'visibleOnMd']}>{rule?.servicePort || '-'}</Td>
+    </Tr>
   );
 };
 

--- a/src/views/ingresses/details/tabs/details/components/IngressRulesSection/RulesRows.tsx
+++ b/src/views/ingresses/details/tabs/details/components/IngressRulesSection/RulesRows.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 
 import { IoK8sApiNetworkingV1IngressSpec } from '@kubevirt-ui/kubevirt-api/kubernetes/models/IoK8sApiNetworkingV1IngressSpec';
+import { Tbody } from '@patternfly/react-table';
 import EmptyBox from '@utils/components/EmptyBox/EmptyBox';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { isEmpty } from '@utils/utils';
@@ -49,11 +50,11 @@ const RulesRows: FC<RulesRowsProps> = ({ namespace, spec }) => {
   }, []);
 
   return (
-    <div className="co-m-table-grid__body">
+    <Tbody>
       {rules.map((rule) => {
         return <RulesRow key={rule.serviceName} namespace={namespace} rule={rule} />;
       })}
-    </div>
+    </Tbody>
   );
 };
 

--- a/src/views/nads/list/components/NADsRow/NADsRow.tsx
+++ b/src/views/nads/list/components/NADsRow/NADsRow.tsx
@@ -45,11 +45,7 @@ const NADsRow: FC<NADsRowType> = ({ activeColumnIDs, obj }) => {
       <TableData activeColumnIDs={activeColumnIDs} id="type">
         {type || <MutedText content={t('Not available')} />}
       </TableData>
-      <TableData
-        activeColumnIDs={activeColumnIDs}
-        className="dropdown-kebab-pf pf-v6-c-table__action"
-        id=""
-      >
+      <TableData activeColumnIDs={activeColumnIDs} className="pf-v6-c-table__action" id="">
         <NADsActions obj={obj} />
       </TableData>
     </>

--- a/src/views/nads/list/hooks/useNADsColumns.tsx
+++ b/src/views/nads/list/hooks/useNADsColumns.tsx
@@ -45,7 +45,7 @@ const useNADsColumns = (): { id: string; title: string }[] => {
       },
       {
         id: '',
-        props: { className: 'dropdown-kebab-pf pf-v6-c-table__action' },
+        props: { className: 'pf-v6-c-table__action' },
         title: '',
       },
     ],

--- a/src/views/networkpolicies/details/tabs/details/components/NetworkPolicyDetailsEgress.tsx
+++ b/src/views/networkpolicies/details/tabs/details/components/NetworkPolicyDetailsEgress.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { Trans } from 'react-i18next';
 
 import { useFlag } from '@openshift-console/dynamic-plugin-sdk';
-import { Divider, Grid, GridItem, Title } from '@patternfly/react-core';
+import { Title } from '@patternfly/react-core';
+import { Table, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
 import ExternalLink from '@utils/components/ExternalLink/ExternalLink';
 import { FLAGS } from '@utils/constants';
 import { getNetworkPolicyDocURL, isManaged } from '@utils/constants/documentation';
@@ -46,15 +47,15 @@ const NetworkPolicyDetailsEgress = ({ networkPolicy }) => {
           namespace: networkPolicy.metadata.namespace,
         })
       ) : (
-        <>
-          <Grid>
-            <GridItem span={4}>{t('From pods')}</GridItem>
-            <GridItem span={4}>{t('To')}</GridItem>
-            <GridItem span={4}>{t('To ports')}</GridItem>
-          </Grid>
-          <Divider />
-
-          <div className="co-m-table-grid__body">
+        <Table gridBreakPoint="">
+          <Thead>
+            <Tr>
+              <Th>{t('From pods')}</Th>
+              <Th>{t('To')}</Th>
+              <Th>{t('To ports')}</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
             {(networkPolicy.spec.egress || []).map((rule, i) =>
               consolidatePeers(rule.to).map((row, j) => (
                 <NetworkPolicyDetailsRow
@@ -66,8 +67,8 @@ const NetworkPolicyDetailsEgress = ({ networkPolicy }) => {
                 />
               )),
             )}
-          </div>
-        </>
+          </Tbody>
+        </Table>
       )}
     </>
   );

--- a/src/views/networkpolicies/details/tabs/details/components/NetworkPolicyDetailsRow/NetworkPolicyDetailsRow.tsx
+++ b/src/views/networkpolicies/details/tabs/details/components/NetworkPolicyDetailsRow/NetworkPolicyDetailsRow.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 
 import { Selector as K8sSelector } from '@openshift-console/dynamic-plugin-sdk';
-import { Grid, GridItem } from '@patternfly/react-core';
+import { Td, Tr } from '@patternfly/react-table';
 import { NetworkPolicyPort } from '@utils/resources/networkpolicies/types';
 
 import { ConsolidatedRow } from '../../utils/types';
@@ -24,22 +24,22 @@ const NetworkPolicyDetailsRow: FC<NetworkPolicyDetailsRowProps> = ({
   row,
 }) => {
   return (
-    <Grid>
-      <GridItem span={4}>
+    <Tr>
+      <Td>
         <NetworkPolicyDetailsRowPodSelector
           mainPodSelector={mainPodSelector}
           namespace={namespace}
         />
-      </GridItem>
-      <GridItem span={4}>
+      </Td>
+      <Td>
         <NetworkPolicyDetailsRowSelector namespace={namespace} row={row} />
-      </GridItem>
-      <GridItem span={4}>
+      </Td>
+      <Td>
         {(ports || []).map((port) => (
           <NetworkPolicyDetailsRowIP key={port.port} port={port} />
         ))}
-      </GridItem>
-    </Grid>
+      </Td>
+    </Tr>
   );
 };
 

--- a/src/views/networkpolicies/list/components/NetworkPolicyRow.tsx
+++ b/src/views/networkpolicies/list/components/NetworkPolicyRow.tsx
@@ -52,11 +52,7 @@ const NetworkPolicyRow: FC<NetworkPolicyRowType> = ({ activeColumnIDs, obj }) =>
           <Selector namespace={obj.metadata.namespace} selector={obj.spec.podSelector} />
         )}
       </TableData>
-      <TableData
-        activeColumnIDs={activeColumnIDs}
-        className="dropdown-kebab-pf pf-v6-c-table__action"
-        id=""
-      >
+      <TableData activeColumnIDs={activeColumnIDs} className="pf-v6-c-table__action" id="">
         <NetworkPolicyActions isKebabToggle obj={obj} />
       </TableData>
     </>

--- a/src/views/networkpolicies/list/hooks/useNetworkPolicyColumn.tsx
+++ b/src/views/networkpolicies/list/hooks/useNetworkPolicyColumn.tsx
@@ -53,7 +53,7 @@ const useNetworkPolicyColumn: UseNetworkPolicyListColumns = (pagination, data) =
     },
     {
       id: '',
-      props: { className: 'dropdown-kebab-pf pf-v6-c-table__action' },
+      props: { className: 'pf-v6-c-table__action' },
       title: '',
     },
   ];

--- a/src/views/routes/details/components/tabs/detailsTab/components/RouteIngressStatusSection/ConditionRow.tsx
+++ b/src/views/routes/details/components/tabs/detailsTab/components/RouteIngressStatusSection/ConditionRow.tsx
@@ -5,6 +5,7 @@ import {
   K8sResourceCondition,
   Timestamp,
 } from '@openshift-console/dynamic-plugin-sdk';
+import { Td, Tr } from '@patternfly/react-table';
 import LinkifyExternal from '@views/routes/details/components/tabs/detailsTab/components/RouteIngressStatusSection/LinkifyExternal';
 import { ClusterServiceVersionCondition, ConditionTypes } from '@views/routes/details/utils/types';
 import { getStatusLabel } from '@views/routes/details/utils/utils';
@@ -17,42 +18,40 @@ type ConditionRowProps = {
 
 const ConditionRow: FC<ConditionRowProps> = ({ condition, index, type }) => {
   return (
-    <div
-      className="row"
+    <Tr
       data-test={type === ConditionTypes.ClusterServiceVersion ? condition.phase : condition.type}
       key={index}
     >
       {type === ConditionTypes.ClusterServiceVersion ? (
-        <div className="col-xs-4 col-sm-2 col-md-2" data-test={`condition[${index}].phase`}>
+        <Td data-test={`condition[${index}].phase`}>
           <CamelCaseWrap value={condition.phase} />
-        </div>
+        </Td>
       ) : (
         <>
-          <div className="col-xs-4 col-sm-2 col-md-2" data-test={`condition[${index}].type`}>
+          <Td data-test={`condition[${index}].type`}>
             <CamelCaseWrap value={condition.type} />
-          </div>
-          <div className="col-xs-4 col-sm-2 col-md-2" data-test={`condition[${index}].status`}>
-            {getStatusLabel(condition.status)}
-          </div>
+          </Td>
+          <Td data-test={`condition[${index}].status`}>{getStatusLabel(condition.status)}</Td>
         </>
       )}
-      <div
-        className="hidden-xs hidden-sm col-md-2"
+      <Td
         data-test={`condition[${index}].lastTransitionTime`}
+        visibility={['hidden', 'visibleOnMd']}
       >
         <Timestamp timestamp={condition.lastTransitionTime} />
-      </div>
-      <div className="col-xs-4 col-sm-3 col-md-2" data-test={`condition[${index}].reason`}>
+      </Td>
+      <Td data-test={`condition[${index}].reason`}>
         <CamelCaseWrap value={condition.reason} />
-      </div>
+      </Td>
       {/* remove initial newline which appears in route messages */}
-      <div
-        className="hidden-xs col-sm-5 col-md-4 co-break-word co-pre-line co-conditions__message"
+      <Td
+        className="co-break-word co-pre-line co-conditions__message"
         data-test={`condition[${index}].message`}
+        visibility={['hidden', 'visibleOnSm']}
       >
         <LinkifyExternal>{condition.message?.trim() || '-'}</LinkifyExternal>
-      </div>
-    </div>
+      </Td>
+    </Tr>
   );
 };
 

--- a/src/views/routes/details/components/tabs/detailsTab/components/RouteIngressStatusSection/Conditions.tsx
+++ b/src/views/routes/details/components/tabs/detailsTab/components/RouteIngressStatusSection/Conditions.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import * as _ from 'lodash';
 
 import { K8sResourceCondition } from '@openshift-console/dynamic-plugin-sdk';
+import { Table, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import ConditionRow from '@views/routes/details/components/tabs/detailsTab/components/RouteIngressStatusSection/ConditionRow';
 import { ClusterServiceVersionCondition, ConditionTypes } from '@views/routes/details/utils/types';
@@ -29,22 +30,24 @@ const Conditions: FC<ConditionsProps> = ({ conditions, type = ConditionTypes.K8s
   }
 
   return (
-    <div className="co-m-table-grid co-m-table-grid--bordered">
-      <div className="row co-m-table-grid__head">
-        {type === ConditionTypes.ClusterServiceVersion ? (
-          <div className="col-xs-4 col-sm-2 col-md-2">{t('Phase')}</div>
-        ) : (
-          <>
-            <div className="col-xs-4 col-sm-2 col-md-2">{t('Type')}</div>
-            <div className="col-xs-4 col-sm-2 col-md-2">{t('Status')}</div>
-          </>
-        )}
-        <div className="hidden-xs hidden-sm col-md-2">{t('Updated')}</div>
-        <div className="col-xs-4 col-sm-3 col-md-2">{t('Reason')}</div>
-        <div className="hidden-xs col-sm-5 col-md-4">{t('Message')}</div>
-      </div>
-      <div className="co-m-table-grid__body">{rows}</div>
-    </div>
+    <Table gridBreakPoint="">
+      <Thead>
+        <Tr>
+          {type === ConditionTypes.ClusterServiceVersion ? (
+            <Th>{t('Phase')}</Th>
+          ) : (
+            <>
+              <Th>{t('Type')}</Th>
+              <Th>{t('Status')}</Th>
+            </>
+          )}
+          <Th visibility={['hidden', 'visibleOnMd']}>{t('Updated')}</Th>
+          <Th>{t('Reason')}</Th>
+          <Th visibility={['hidden', 'visibleOnSm']}>{t('Message')}</Th>
+        </Tr>
+      </Thead>
+      <Tbody>{rows}</Tbody>
+    </Table>
   );
 };
 

--- a/src/views/services/list/hooks/useServiceColumn.tsx
+++ b/src/views/services/list/hooks/useServiceColumn.tsx
@@ -58,7 +58,7 @@ const useServiceColumn = (): { id: string; title: string }[] => {
       },
       {
         id: '',
-        props: { className: 'dropdown-kebab-pf pf-c-table__action' },
+        props: { className: 'pf-c-table__action' },
         title: '',
       },
     ],

--- a/src/views/udns/list/components/UserDefinedNetworkRow.tsx
+++ b/src/views/udns/list/components/UserDefinedNetworkRow.tsx
@@ -52,11 +52,7 @@ const UserDefinedNetworkRow: FC<UserDefinedNetworkRowType> = ({ activeColumnIDs,
       <TableData activeColumnIDs={activeColumnIDs} id="mtu">
         {mtu || <MutedText content={t('Not available')} />}
       </TableData>
-      <TableData
-        activeColumnIDs={activeColumnIDs}
-        className="dropdown-kebab-pf pf-v6-c-table__action"
-        id=""
-      >
+      <TableData activeColumnIDs={activeColumnIDs} className="pf-v6-c-table__action" id="">
         <UDNActions obj={obj} />
       </TableData>
     </>

--- a/src/views/udns/list/hooks/useUDNColumns.tsx
+++ b/src/views/udns/list/hooks/useUDNColumns.tsx
@@ -59,7 +59,7 @@ const useUDNColumns = (): { id: string; title: string }[] => {
       },
       {
         id: '',
-        props: { className: 'dropdown-kebab-pf pf-v6-c-table__action' },
+        props: { className: 'pf-v6-c-table__action' },
         title: '',
       },
     ],


### PR DESCRIPTION
- replaces `co-m-table-grid` and related classes with PatternFly `Table` 
- removes `dropdown-kebab-pf` classes

Before:
<img width="1429" alt="Screenshot 2025-04-14 at 11 38 33" src="https://github.com/user-attachments/assets/96867873-94fe-4390-8d10-69ff7615fc8a" />
<img width="1429" alt="Screenshot 2025-04-14 at 11 38 22" src="https://github.com/user-attachments/assets/29e3647f-c9f7-4039-a223-6c138f48022f" />


After:
<img width="1450" alt="Screenshot 2025-04-14 at 10 51 15" src="https://github.com/user-attachments/assets/31fbfa30-7839-4b01-9b1e-f02e278b7568" />
<img width="1429" alt="Screenshot 2025-04-14 at 11 18 18" src="https://github.com/user-attachments/assets/e3a555f9-2740-48aa-85d7-ab8e1cc454bb" />
