### PR TITLE
CNV-60065: fix cudn input name

### DIFF
--- a/src/views/udns/list/components/UserDefinedNetworkCreateForm.tsx
+++ b/src/views/udns/list/components/UserDefinedNetworkCreateForm.tsx
@@ -40,10 +40,7 @@ const UserDefinedNetworkCreateForm: FC<UserDefinedNetworkCreateFormProps> = ({
           <TextInput
             autoFocus
             data-test="input-name"
-            id="input-name"
             {...register('metadata.name', { required: true })}
-            isRequired
-            name="name"
           />
         </FormGroup>
       )}


### PR DESCRIPTION
the input was not changing the state and cudn got created with the original generated name. 

The `name` prop was overlapping with `react-hook-form` library `register` method 