### PR TITLE
CNV-61902: fetch description of terms for popovers

### DIFF
--- a/src/utils/components/DetailsItem/DetailsItem.tsx
+++ b/src/utils/components/DetailsItem/DetailsItem.tsx
@@ -20,6 +20,7 @@ import { PencilAltIcon } from '@patternfly/react-icons/dist/esm/icons/pencil-alt
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 
 import { getPropertyDescription } from './swagger';
+import LinkifyExternal from '@views/routes/details/components/tabs/detailsTab/components/RouteIngressStatusSection/LinkifyExternal';
 
 export const PropertyPath: FC<{
   kind: string;
@@ -92,7 +93,11 @@ export const DetailsItem: FC<DetailsItemProps> = ({
               <Popover
                 headerContent={<div>{label}</div>}
                 {...(popoverContent && {
-                  bodyContent: <div className="co-pre-line">{popoverContent}</div>,
+                  bodyContent: (
+                    <LinkifyExternal>
+                      <div className="co-pre-line">{popoverContent}</div>
+                    </LinkifyExternal>
+                  ),
                 })}
                 {...(path && {
                   footerContent: <PropertyPath kind={model?.kind} path={path} />,


### PR DESCRIPTION
- short term fix, it is a copy of console code
- sometimes it takes a while to fetch the description so the popover content might not show up immediately
- we should rely on `getSwaggerPropertyDescription` function from `console-dynamic-plugin-sdk` once it is exposed, this is a PR in console to expose it: https://github.com/openshift/console/pull/15075

Before:
<img width="1714" alt="Screenshot 2025-05-15 at 18 01 05" src="https://github.com/user-attachments/assets/728e9745-efd0-409e-92d0-ef1523881e12" />


After:

https://github.com/user-attachments/assets/d5a8f5bd-a61a-42b1-8144-a67fdc93e9ff

(don't mind the styling issues, those are fixed by another PR)