### PR TITLE
OCPBUGS-49386: Fix pod contenxt

### DIFF
--- a/src/views/services/details/tabs/pods/components/PodRow.tsx
+++ b/src/views/services/details/tabs/pods/components/PodRow.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import classNames from 'classnames';
 import * as _ from 'lodash';
 
-import { modelToGroupVersionKind, modelToRef, PodModel } from '@kubevirt-ui/kubevirt-api/console';
+import { modelToGroupVersionKind, PodModel } from '@kubevirt-ui/kubevirt-api/console';
 import { IoK8sApiCoreV1Pod } from '@kubevirt-ui/kubevirt-api/kubernetes/models';
 import {
   PrometheusResponse,
@@ -39,8 +39,7 @@ const PodRow: FC<PodRowType> = ({
   const { readyCount, totalContainers } = podReadiness(pod);
   const phase = podPhase(pod);
   const restarts = podRestarts(pod);
-  const resourceKind = modelToRef(PodModel);
-  const context = { [resourceKind]: pod };
+  const context = { [`core~${PodModel.apiVersion}~${PodModel.kind}`]: pod };
 
   const cores = getPodCPUUsage(cpuUsageData, pod);
   const bytes = getPodMemoryUsage(memoryUsageData, pod);


### PR DESCRIPTION
`modelToRef` do not handle the case where model does not have `core` as an `apiGroup`. We should fix that in the `kubevirt-api` but in the meantime, do not use it  

<img width="1918" alt="Screenshot 2025-06-05 at 14 23 43" src="https://github.com/user-attachments/assets/41696f89-6cc4-4db5-a461-df2c70d8802b" />
