### PR TITLE
OCPBUGS-61548: use console extension to render same nad actions 

### DIFF
--- a/src/views/nads/actions/hooks/useNADsActions.tsx
+++ b/src/views/nads/actions/hooks/useNADsActions.tsx
@@ -6,17 +6,22 @@ import {
   Action,
   useAnnotationsModal,
   useDeleteModal,
+  useK8sModel,
   useLabelsModal,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { isUserDefinedNetworkNAD } from '@utils/resources/nads/helpers';
 import { NetworkAttachmentDefinitionKind } from '@utils/resources/nads/types';
 import { asAccessReview, getName, getNamespace } from '@utils/resources/shared';
+import { useMemo } from 'react';
 
-type NADsActionsProps = (obj: NetworkAttachmentDefinitionKind) => [actions: Action[]];
+type NADsActionsProps = (
+  obj: NetworkAttachmentDefinitionKind,
+) => [actions: Action[], inFlight: boolean, error: any];
 
 const useNADsActions: NADsActionsProps = (obj) => {
   const { t } = useNetworkingTranslation();
+  const [, inFlight] = useK8sModel(NetworkAttachmentDefinitionModelRef);
 
   const isUDNManaged = isUserDefinedNetworkNAD(obj);
   const navigate = useNavigate();
@@ -27,43 +32,58 @@ const useNADsActions: NADsActionsProps = (obj) => {
   const objNamespace = getNamespace(obj);
   const objName = getName(obj);
 
-  const actions = [
-    {
-      accessReview: asAccessReview(NetworkAttachmentDefinitionModel, obj, 'update'),
-      cta: launchLabelsModal,
-      description: isUDNManaged && t('Managed by UserDefinedNetwork'),
-      disabled: isUDNManaged,
-      id: 'edit-labels-nad',
-      label: t('Edit labels'),
-    },
-    {
-      accessReview: asAccessReview(NetworkAttachmentDefinitionModel, obj, 'update'),
-      cta: launchAnnotationsModal,
-      description: isUDNManaged && t('Managed by UserDefinedNetwork'),
-      disabled: isUDNManaged,
-      id: 'edit-annotations-nad',
-      label: t('Edit annotations'),
-    },
-    {
-      accessReview: asAccessReview(NetworkAttachmentDefinitionModel, obj, 'update'),
-      cta: () =>
-        navigate(`/k8s/ns/${objNamespace}/${NetworkAttachmentDefinitionModelRef}/${objName}/yaml`),
-      description: isUDNManaged && t('Managed by UserDefinedNetwork'),
-      disabled: isUDNManaged,
-      id: 'edit-nad',
-      label: t('Edit NetworkAttachmentDefinition'),
-    },
-    {
-      accessReview: asAccessReview(NetworkAttachmentDefinitionModel, obj, 'delete'),
-      cta: launchDeleteModal,
-      description: isUDNManaged && t('Managed by UserDefinedNetwork'),
-      disabled: isUDNManaged,
-      id: 'delete-nad',
-      label: t('Delete NetworkAttachmentDefinition'),
-    },
-  ];
+  return useMemo(() => {
+    const actions = [
+      {
+        accessReview: asAccessReview(NetworkAttachmentDefinitionModel, obj, 'update'),
+        cta: launchLabelsModal,
+        description: isUDNManaged && t('Managed by UserDefinedNetwork'),
+        disabled: isUDNManaged,
+        id: 'edit-labels-nad',
+        label: t('Edit labels'),
+      },
+      {
+        accessReview: asAccessReview(NetworkAttachmentDefinitionModel, obj, 'update'),
+        cta: launchAnnotationsModal,
+        description: isUDNManaged && t('Managed by UserDefinedNetwork'),
+        disabled: isUDNManaged,
+        id: 'edit-annotations-nad',
+        label: t('Edit annotations'),
+      },
+      {
+        accessReview: asAccessReview(NetworkAttachmentDefinitionModel, obj, 'update'),
+        cta: () =>
+          navigate(
+            `/k8s/ns/${objNamespace}/${NetworkAttachmentDefinitionModelRef}/${objName}/yaml`,
+          ),
+        description: isUDNManaged && t('Managed by UserDefinedNetwork'),
+        disabled: isUDNManaged,
+        id: 'edit-nad',
+        label: t('Edit NetworkAttachmentDefinition'),
+      },
+      {
+        accessReview: asAccessReview(NetworkAttachmentDefinitionModel, obj, 'delete'),
+        cta: launchDeleteModal,
+        description: isUDNManaged && t('Managed by UserDefinedNetwork'),
+        disabled: isUDNManaged,
+        id: 'delete-nad',
+        label: t('Delete NetworkAttachmentDefinition'),
+      },
+    ];
 
-  return [actions];
+    return [actions, !inFlight, undefined];
+  }, [
+    obj,
+    inFlight,
+    launchAnnotationsModal,
+    launchDeleteModal,
+    launchLabelsModal,
+    navigate,
+    objNamespace,
+    objName,
+    isUDNManaged,
+    t,
+  ]);
 };
 
 export default useNADsActions;

--- a/src/views/nads/manifest.ts
+++ b/src/views/nads/manifest.ts
@@ -1,6 +1,7 @@
 import { EncodedExtension } from '@openshift/dynamic-plugin-sdk-webpack';
 import {
   DetailsItem,
+  ResourceActionProvider,
   ResourceListPage,
   ResourceNSNavItem,
   RoutePage,
@@ -77,10 +78,20 @@ export const NADsExtensions: EncodedExtension[] = [
     },
     type: 'console.yaml-template',
   } as EncodedExtension<YAMLTemplate>,
+  {
+    properties: {
+      model: NetworkAttachmentDefinitionExtensionModel,
+      provider: {
+        $codeRef: 'useNADsActions',
+      },
+    },
+    type: 'console.action/resource-provider',
+  } as EncodedExtension<ResourceActionProvider>,
 ];
 
 export const NADsExposedModules: ConsolePluginBuildMetadata['exposedModules'] = {
   NetworkAttachmentDefinitionFormPage: './views/nads/form/NetworkAttachmentDefinitionFormPage.tsx',
   NetworkAttachmentDefinitionList: './views/nads/list/NetworkAttachmentDefinitionList.tsx',
   NetworkAttachmentDefintionTypeDetails: './views/nads/details/tabs/details/NADTypeDetails.tsx',
+  useNADsActions: './views/nads/actions/hooks/useNADsActions.tsx',
 };


### PR DESCRIPTION



With this, we'll be able to see the same actions in the NAD details page (that we do not currently customize) 