### PR TITLE
OCPBUGS-61531: show VM network menu only on admin

### DIFF
--- a/src/views/vmnetworks/manifest.ts
+++ b/src/views/vmnetworks/manifest.ts
@@ -6,6 +6,9 @@ import { VM_NETWORKS_PATH } from './constants';
 
 export const VMNetworksExtensions: EncodedExtension[] = [
   {
+    flags: {
+      required: ['CAN_LIST_NS'],
+    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-vmnetwork',
@@ -21,8 +24,10 @@ export const VMNetworksExtensions: EncodedExtension[] = [
     },
     type: 'console.navigation/href',
   } as EncodedExtension<HrefNavItem>,
-
   {
+    flags: {
+      required: ['CAN_LIST_NS'],
+    },
     properties: {
       dataAttributes: {
         'data-quickstart-id': 'qs-nav-vmnetwork',


### PR DESCRIPTION
`CAN_LIST_NS` is the flag that we use to determine if the user is an admin

usage: `useIsAdmin` hook