### PR TITLE
CNV-59876: use correct name space when switching tabs

### DIFF
--- a/src/views/networkpolicies/list/NetworkPolicyPage.tsx
+++ b/src/views/networkpolicies/list/NetworkPolicyPage.tsx
@@ -2,13 +2,18 @@ import React, { FC, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 
 import { modelToGroupVersionKind, NetworkPolicyModel } from '@kubevirt-ui/kubevirt-api/console';
-import { ListPageCreateButton, ListPageHeader } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  ListPageCreateButton,
+  ListPageHeader,
+  useActiveNamespace,
+} from '@openshift-console/dynamic-plugin-sdk';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import { ALL_NAMESPACES, DEFAULT_NAMESPACE } from '@utils/constants';
 import { SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM } from '@utils/constants/ui';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { MultiNetworkPolicyModel } from '@utils/models';
 import { resourcePathFromModel } from '@utils/resources/shared';
+import { getValidNamespace } from '@utils/utils';
 
 import useIsMultiEnabled from './hooks/useIsMultiEnabled';
 import { TAB_INDEXES } from './constants';
@@ -17,14 +22,11 @@ import MultiNetworkPolicyList from './MultiNetworkPolicyList';
 import NetworkPolicyList from './NetworkPolicyList';
 import { getActiveKeyFromPathname, getNetworkPolicyURLTab } from './utils';
 
-export type NetworkPolicyPageNavProps = {
-  namespace: string;
-};
-
-const NetworkPolicyPage: FC<NetworkPolicyPageNavProps> = ({ namespace }) => {
+const NetworkPolicyPage: FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
-
+  const [activeNamespace] = useActiveNamespace();
+  const namespace = getValidNamespace(activeNamespace);
   const locationTabKey = useMemo(
     () => getActiveKeyFromPathname(location?.pathname),
     [location?.pathname],

--- a/src/views/networkpolicies/new/NADsSelector.tsx
+++ b/src/views/networkpolicies/new/NADsSelector.tsx
@@ -58,13 +58,12 @@ const NADsSelector: FC<NADsSelectorProps> = ({ namespace, networkPolicy, onPolic
         {loadError}
       </Alert>
     );
-
   return (
     <FormGroup fieldId="multi-networkpolicy-policyfor" isRequired label={t('Policy for')}>
       <SelectMultiTypeahead
         options={nadsOptions}
         placeholder={t('Select one or more NetworkAttachmentDefinitions')}
-        selected={networkPolicy.policyFor}
+        selected={networkPolicy.policyFor || []}
         setSelected={onChange}
       />
     </FormGroup>


### PR DESCRIPTION
Description:

[CNV-59876](https://issues.redhat.com/browse/CNV-59876): Project selector resets to All projects for nonpriv user

Before:

https://github.com/user-attachments/assets/1c641a3e-d8ff-46bc-9aa4-5278b378bf0e


After

https://github.com/user-attachments/assets/5d0dde49-3e90-4f10-9134-ec764baca57f


Also fixed this bug:

https://github.com/user-attachments/assets/8c6d725c-c90a-44f5-8d74-cd2669f42991

