### PR TITLE
CNV-60063: fixing the Create ClusterUserDefinedNetwork form appearance

### DIFF
--- a/src/utils/components/MatchLabels/MatchLabels.tsx
+++ b/src/utils/components/MatchLabels/MatchLabels.tsx
@@ -21,7 +21,7 @@ const MatchLabels: FC<MatchLabelsProps> = ({
   const { t } = useNetworkingTranslation();
 
   return (
-    <FormGroup fieldId={fieldId} label={t('Match Labels')}>
+    <FormGroup fieldId={fieldId} isRequired label={t('Match Labels')}>
       <SelectorInput
         autoFocus
         inputProps={{ id: fieldId }}

--- a/src/views/udns/list/components/ClusterUDNNamespaceSelector.tsx
+++ b/src/views/udns/list/components/ClusterUDNNamespaceSelector.tsx
@@ -29,7 +29,7 @@ const ClusterUDNNamespaceSelector: FC = () => {
   const matchingProjects = projects?.filter((project) => match(project, matchLabels));
 
   return (
-    <FormSection title={t('Project(s)')} titleElement="h2">
+    <FormSection title={t('Namespace(s)')} titleElement="h2">
       <MatchLabels
         matchLabels={matchLabels}
         onChange={(newMatchLabels) =>
@@ -40,7 +40,9 @@ const ClusterUDNNamespaceSelector: FC = () => {
       <ExpandableSection
         isExpanded={isExpanded}
         onToggle={onToggle}
-        toggleText={isExpanded ? t('Hide selected project(s)') : t('Review selected project(s)')}
+        toggleText={
+          isExpanded ? t('Hide selected Namespace(s)') : t('Review selected Namespace(s)')
+        }
       >
         <List isPlain>
           {matchingProjects.map((project) => (


### PR DESCRIPTION
Fixing the Create ClusterUserDefinedNetwork form so there is a red asterisk next to Match Labels, since it's mandatory field and changing "project(s)" to "Namespace(s)"