### PR TITLE
Fix OOM during production webpack build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "dev": "NODE_ENV=development NODE_OPTIONS=--max-old-space-size=8192 rm -rf dist && npm run ts-node -- ./node_modules/.bin/webpack serve --progress",
-    "build": "npm run clean && NODE_ENV=production npm run ts-node -- node_modules/.bin/webpack",
+    "build": "npm run clean && NODE_ENV=production NODE_OPTIONS=--max-old-space-size=4096 npm run ts-node -- node_modules/.bin/webpack",
     "build-dev": "npm run clean && npm run ts-node -- node_modules/.bin/webpack",
     "start": "npm run ts-node -- node_modules/.bin/webpack serve",
     "start-console": "./start-console.sh",


### PR DESCRIPTION
## Summary
- The CI `images` job can fail with `SIGKILL` (OOM kill) during the webpack production build because the process exceeds the container memory limit.
- Set `NODE_OPTIONS=--max-old-space-size=4096` in the `build` script, matching the pattern already used by the `dev` script (which sets 8192MB).

## Test plan
- [ ] CI `images` job should pass without OOM


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build process configuration to improve stability and performance during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->