### PR TITLE
OCPBUGS-74912: Fix namespace resolution and resource path for Routes and Services list pages

### DIFF
--- a/src/utils/resources/shared.ts
+++ b/src/utils/resources/shared.ts
@@ -142,7 +142,7 @@ export const resourcePathFromModel = (
     url += namespace ? `ns/${namespace}/` : 'all-namespaces/';
   }
 
-  url += `${model.apiGroup}~${model.apiVersion}~${model.kind}`;
+  url += `${model.apiGroup || CORE}~${model.apiVersion}~${model.kind}`;
 
   if (name) {
     // Some resources have a name that needs to be encoded. For instance,

--- a/src/views/routes/list/RoutesList.tsx
+++ b/src/views/routes/list/RoutesList.tsx
@@ -7,17 +7,18 @@ import {
   ListPageCreateButton,
   ListPageFilter,
   ListPageHeader,
+  useActiveNamespace,
   useK8sWatchResource,
   useListPageFilter,
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
 import ListEmptyState from '@utils/components/ListEmptyState/ListEmptyState';
-import { DEFAULT_NAMESPACE } from '@utils/constants';
 import { documentationURLs, getDocumentationURL } from '@utils/constants/documentation';
 import { SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM } from '@utils/constants/ui';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { resourcePathFromModel } from '@utils/resources/shared';
 import { RouteKind } from '@utils/types';
+import { getValidNamespace } from '@utils/utils';
 import RouteRow from '@views/routes/list/components/RouteRow';
 import useRouteColumns from '@views/routes/list/hooks/useRouteColumns';
 
@@ -30,6 +31,8 @@ type RoutesListProps = {
 const RoutesList: FC<RoutesListProps> = ({ namespace }) => {
   const { t } = useNetworkingTranslation();
   const navigate = useNavigate();
+  const [activeNamespace] = useActiveNamespace();
+  const validNamespace = getValidNamespace(namespace || activeNamespace);
 
   const [routesFetch, loaded, loadError] = useK8sWatchResource<RouteKind[]>({
     groupVersionKind: modelToGroupVersionKind(RouteModel),
@@ -40,11 +43,18 @@ const RoutesList: FC<RoutesListProps> = ({ namespace }) => {
   const routeFilters = useRouteFilters();
   const [data, filteredData, onFilterChange] = useListPageFilter(routesFetch, routeFilters);
   const columns = useRouteColumns();
+
+  const routeCreateFormLink = `${resourcePathFromModel(
+    RouteModel,
+    null,
+    validNamespace,
+  )}/${SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}`;
+
   const title = t('Routes');
 
   return (
     <ListEmptyState<RouteKind>
-      createButtonlink={SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}
+      createButtonlink={routeCreateFormLink}
       data={routesFetch}
       error={loadError}
       kind={RouteModel.kind}
@@ -57,17 +67,9 @@ const RoutesList: FC<RoutesListProps> = ({ namespace }) => {
           className="list-page-create-button-margin"
           createAccessReview={{
             groupVersionKind: modelToGroupVersionKind(RouteModel),
-            namespace,
+            namespace: validNamespace,
           }}
-          onClick={() =>
-            navigate(
-              `${resourcePathFromModel(
-                RouteModel,
-                null,
-                namespace || DEFAULT_NAMESPACE,
-              )}/${SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}`,
-            )
-          }
+          onClick={() => navigate(routeCreateFormLink)}
         >
           {t('Create Route')}
         </ListPageCreateButton>

--- a/src/views/services/list/ServiceList.tsx
+++ b/src/views/services/list/ServiceList.tsx
@@ -8,19 +8,17 @@ import {
   ListPageCreateButton,
   ListPageFilter,
   ListPageHeader,
+  useActiveNamespace,
   useK8sWatchResource,
   useListPageFilter,
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
 import ListEmptyState from '@utils/components/ListEmptyState/ListEmptyState';
-import { DEFAULT_NAMESPACE } from '@utils/constants';
 import { DOC_URL_NETWORK_SERVICE } from '@utils/constants/documentation';
-import {
-  SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM,
-  SHARED_DEFAULT_PATH_NEW_RESOURCE_YAML,
-} from '@utils/constants/ui';
+import { SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM } from '@utils/constants/ui';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { resourcePathFromModel } from '@utils/resources/shared';
+import { getValidNamespace } from '@utils/utils';
 
 import ServiceRow from './components/ServiceRow';
 import useServiceColumn from './hooks/useServiceColumn';
@@ -33,6 +31,8 @@ type ServiceListProps = {
 const ServiceList: FC<ServiceListProps> = ({ namespace }) => {
   const { t } = useNetworkingTranslation();
   const navigate = useNavigate();
+  const [activeNamespace] = useActiveNamespace();
+  const validNamespace = getValidNamespace(namespace || activeNamespace);
 
   const [service, loaded, loadError] = useK8sWatchResource<IoK8sApiCoreV1Service[]>({
     groupVersionKind: modelToGroupVersionKind(ServiceModel),
@@ -42,11 +42,18 @@ const ServiceList: FC<ServiceListProps> = ({ namespace }) => {
 
   const [data, filteredData, onFilterChange] = useListPageFilter(service);
   const columns = useServiceColumn();
+
+  const serviceCreateFormLink = `${resourcePathFromModel(
+    ServiceModel,
+    null,
+    validNamespace,
+  )}/${SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}`;
+
   const title = t('Services');
 
   return (
     <ListEmptyState<IoK8sApiCoreV1Service>
-      createButtonlink={SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}
+      createButtonlink={serviceCreateFormLink}
       data={data}
       error={loadError}
       kind={ServiceModel.kind}
@@ -54,22 +61,14 @@ const ServiceList: FC<ServiceListProps> = ({ namespace }) => {
       loaded={loaded}
       title={title}
     >
-      <ListPageHeader title={t('Services')}>
+      <ListPageHeader title={title}>
         <ListPageCreateButton
           className="list-page-create-button-margin"
           createAccessReview={{
             groupVersionKind: modelToGroupVersionKind(ServiceModel),
-            namespace,
+            namespace: validNamespace,
           }}
-          onClick={() =>
-            navigate(
-              `${resourcePathFromModel(
-                ServiceModel,
-                null,
-                namespace || DEFAULT_NAMESPACE,
-              )}/${SHARED_DEFAULT_PATH_NEW_RESOURCE_YAML}`,
-            )
-          }
+          onClick={() => navigate(serviceCreateFormLink)}
         >
           {t('Create Service')}
         </ListPageCreateButton>


### PR DESCRIPTION
## Summary
took the opportunity to change some small things about namespace .

- Use `useActiveNamespace` hook with `getValidNamespace` utility to properly resolve the namespace when creating Routes and Services from list pages, instead of falling back to `DEFAULT_NAMESPACE`.
- Fix `resourcePathFromModel` to use the `CORE` constant when `apiGroup` is empty, ensuring correct URL paths for core API resources like Services.
- Extract create form link into a variable in both `RoutesList` and `ServiceList` to avoid duplication.

## Test plan
- [ ] Verify creating a Route from the Routes list page navigates to the correct namespace in the form URL
- [ ] Verify creating a Service from the Services list page navigates to the correct namespace in the form URL
- [ ] Verify that switching namespaces and then clicking "Create" uses the correct active namespace
- [ ] Verify that the `all-namespaces` view correctly resolves to `default` namespace when creating resources


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Defaulted API group to CORE when none is specified, preventing incorrect resource path generation.
  * Improved namespace handling for route and service creation: validates/uses the correct namespace for creation links and access checks, and updates navigation for create actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->