### PR TITLE
CNV-81752: Fix runtime error when clicking "Create Route"

### DIFF
--- a/src/utils/components/SyncedEditor/useEditorType.ts
+++ b/src/utils/components/SyncedEditor/useEditorType.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { useUserSettings } from '@openshift-console/dynamic-plugin-sdk-internal';
+import { useUserSettings } from '@openshift-console/dynamic-plugin-sdk';
 import {
   PREFERRED_CREATE_EDIT_METHOD_USER_SETTING_VALUE_LATEST,
   usePreferredCreateEditMethod,

--- a/src/utils/hooks/usePreferredCreateEditMethod.ts
+++ b/src/utils/hooks/usePreferredCreateEditMethod.ts
@@ -1,4 +1,4 @@
-import { useUserSettings } from '@openshift-console/dynamic-plugin-sdk-internal';
+import { useUserSettings } from '@openshift-console/dynamic-plugin-sdk';
 
 export const PREFERRED_CREATE_EDIT_METHOD_USER_SETTING_VALUE_LATEST = 'latest';
 const PREFERRED_CREATE_EDIT_METHOD_USER_SETTING_KEY = 'console.preferredCreateEditMethod';


### PR DESCRIPTION
Fix runtime error when clicking "Create Route"

- Import `useUserSettings` from the public SDK (`@openshift-console/dynamic-plugin-sdk`) instead of the deprecated internal package (`@openshift-console/dynamic-plugin-sdk-internal`)

Before:

https://github.com/user-attachments/assets/71d309a9-fdd9-4582-8518-d00e7b40f865

After:

https://github.com/user-attachments/assets/b65a9539-cbf0-4531-b7a2-23a0b0ef19a8



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal SDK dependencies to use public API sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->