### PR TITLE
Align Dockerfile.art with OCP 4.22 images and npm-based ART build

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -3,25 +3,10 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-openshift-4.21 AS 
 
 # Copy app source
 COPY . /opt/app-root/src/app
-COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
 WORKDIR /opt/app-root/src/app
 
-# bootstrap yarn so we can install and run the other tools.
-USER 0
-ARG YARN_VERSION=v1.22.19
-RUN CACHED_YARN=./artifacts/yarn-${YARN_VERSION}.tar.gz; \
-    if [ -f ${CACHED_YARN} ]; then \
-      npm install -g ${CACHED_YARN}; \
-    else \
-      echo "need yarn at ${CACHED_YARN}"; \
-      exit 1; \
-    fi
-
-# use dependencies provided by Cachito
-RUN test -d ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps || exit 1; \
-    cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/{.npmrc,.yarnrc,yarn.lock,registry-ca.pem} . \
- && source ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env \
- && npm ci && npm run build
+# Install dependencies and build
+RUN CYPRESS_INSTALL_BINARY=0 npm ci && npm run build
 
 # Web server container
 FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
@@ -29,11 +14,11 @@ FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
 RUN INSTALL_PKGS="nginx" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum -y clean all --enablerepo='*' && rm -rf /var/cache/dnf/* && \
+    dnf -y clean all --enablerepo='*' && rm -rf /var/cache/dnf/* && \
     chown -R 1001:0 /var/lib/nginx /var/log/nginx /run && \
     chmod -R ug+rwX /var/lib/nginx /var/log/nginx /run
 
-# Use none-root user
+# Use non-root user
 USER 1001
 
 COPY --from=build /opt/app-root/src/app/dist /opt/app-root/src


### PR DESCRIPTION
## Summary

Updates `Dockerfile.art` on the `release-4.21` line to use the 4.22 builder/runtime base images and a straightforward `npm ci` / `npm run build` flow.

## Changes

- Bump builder and runtime `FROM` images to `rhel-9-base-nodejs-openshift-4.22` and `ocp/4.22:base-rhel9`.
- Remove Cachito / `REMOTE_SOURCES` and Yarn bootstrap; build with `CYPRESS_INSTALL_BINARY=0 npm ci && npm run build`.
- Use `dnf` for image cleanup (replacing `yum`).
- Minor comment fix: "none-root" → "non-root".