### PR TITLE
[Release-4.21] OCPBUGS-81620: Update lodash to 4.18.1 for CVE-2026-4800

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "i18next-conv": "12.1.1",
         "i18next-parser": "^9.4.0",
         "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "mocha-junit-reporter": "^2.2.0",
         "mochawesome": "^7.1.3",
         "mochawesome-merge": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "i18next-conv": "12.1.1",
     "i18next-parser": "^9.4.0",
     "js-yaml": "^4.1.0",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "mocha-junit-reporter": "^2.2.0",
     "mochawesome": "^7.1.3",
     "mochawesome-merge": "^4.3.0",


### PR DESCRIPTION
- Bump lodash minimum version to 4.18.1 to fix CVE-2026-4800. Lock file already has 4.18.1; updating package.json for consistency and safety. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->