### PR TITLE
[Release-4.19] OCPBUGS-83384: Fix CVE-2026-34043 in serialize-javascript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15604,16 +15604,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -16774,13 +16764,13 @@
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-index": {

--- a/package.json
+++ b/package.json
@@ -123,5 +123,8 @@
     "lodash": "^4.18.1",
     "lodash-es": "^4.18.1",
     "@remix-run/router": "^1.23.2"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
   }
 }


### PR DESCRIPTION
**copy-webpack-plugin@14.0.0** requires Node.js ≥ 20.9.0, So override serialize-javascript to patched version 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution configuration to ensure consistent version convergence for a transitive package dependency. This change pins the specific transitive package version in project configuration.
  * No changes to public APIs or runtime-visible features; end-user behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->