### PR TITLE
[Release-4.18] OCPBUGS-73647: CVE-2026-22029 fix to @remix-run/router to 1.23.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-i18next": "^11.7.3",
     "react-router": "5.3.x",
     "react-router-dom": "5.3.x",
-    "react-router-dom-v5-compat": "^6.22.2",
+    "react-router-dom-v5-compat": "^6.30.0",
     "resolve-url-loader": "^5.0.0",
     "sass": "^1.71.1",
     "sass-loader": "^12.4.0",
@@ -107,6 +107,7 @@
     "@openshift-console/dynamic-plugin-sdk-internal/immutable": "3.8.3",
     "sass/immutable": "4.3.8",
     "lodash": "^4.18.1",
-    "lodash-es": "^4.18.1"
+    "lodash-es": "^4.18.1",
+    "@remix-run/router": "^1.23.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -109,5 +109,12 @@
     "lodash": "^4.18.1",
     "lodash-es": "^4.18.1",
     "@remix-run/router": "^1.23.2"
+  },
+  "overrides": {
+    "@patternfly/quickstarts": {
+      "react": "$react",
+      "react-dom": "$react-dom"
+    },
+    "@remix-run/router": "^1.23.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -441,10 +441,10 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
   integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
 
-"@remix-run/router@1.15.3":
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.15.3.tgz#d2509048d69dbb72d5389a14945339f1430b2d3c"
-  integrity sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==
+"@remix-run/router@1.15.3", "@remix-run/router@1.23.2", "@remix-run/router@^1.23.2":
+  version "1.23.2"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.2.tgz#156c4b481c0bee22a19f7924728a67120de06971"
+  integrity sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.11"
@@ -5595,13 +5595,22 @@ react-redux@7.2.2:
     prop-types "^15.7.2"
     react-is "^16.13.1"
 
-react-router-dom-v5-compat@^6.11.2, react-router-dom-v5-compat@^6.22.2:
+react-router-dom-v5-compat@^6.11.2:
   version "6.22.3"
   resolved "https://registry.yarnpkg.com/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.22.3.tgz#4889b46d060492a58c401700c987bddcc8b915f4"
   integrity sha512-icbyLKEUdMqWjehsRrQv0g/N4C33KFC2ZmnOBF7vvy1hudYSJWY4VTOjy3ey2YY+r3WtcdEH72M7IIGVHAkEtw==
   dependencies:
     history "^5.3.0"
     react-router "6.22.3"
+
+react-router-dom-v5-compat@^6.30.0:
+  version "6.30.3"
+  resolved "https://registry.yarnpkg.com/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.3.tgz#0bd5ccc0d9fc0e81ceabade75acc55240279aaaf"
+  integrity sha512-WWZtwGYyoaeUDNrhzzDkh4JvN5nU0MIz80Dxim6pznQrfS+dv0mvtVoHTA6HlUl/OiJl7WWjbsQwjTnYXejEHg==
+  dependencies:
+    "@remix-run/router" "1.23.2"
+    history "^5.3.0"
+    react-router "6.30.3"
 
 react-router-dom@5.3.x:
   version "5.3.4"
@@ -5637,6 +5646,13 @@ react-router@6.22.3:
   integrity sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==
   dependencies:
     "@remix-run/router" "1.15.3"
+
+react-router@6.30.3:
+  version "6.30.3"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.3.tgz#994b3ccdbe0e81fe84d4f998100f62584dfbf1cf"
+  integrity sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==
+  dependencies:
+    "@remix-run/router" "1.23.2"
 
 react-side-effect@^2.1.0:
   version "2.1.2"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated routing and related dependency constraints to ensure compatibility with newer package manager resolutions.
  * Added override rules so the project consistently uses the resolved routing and UI quickstart libraries aligned with the project's React runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->