### PR TITLE
OCPBUGS-41605: Retain namespace selection between network policies tabs

### DIFF
--- a/src/utils/utils/helpers.ts
+++ b/src/utils/utils/helpers.ts
@@ -1,6 +1,6 @@
 import { animals, colors, uniqueNamesGenerator } from 'unique-names-generator';
 
-import { ALL_NAMESPACES_KEY, DEFAULT_NAMESPACE } from '@utils/constants';
+import { ALL_NAMESPACES, ALL_NAMESPACES_KEY, DEFAULT_NAMESPACE } from '@utils/constants';
 
 export const networkConsole = console;
 
@@ -13,6 +13,9 @@ export const generateName = (prefix: string): string => {
     separator: '-',
   })}`;
 };
+
+export const createNamespacePath = (namespace: string) =>
+  namespace ? `ns/${namespace}` : ALL_NAMESPACES;
 
 export const getValidNamespace = (activeNamespace: string) =>
   activeNamespace === ALL_NAMESPACES_KEY ? DEFAULT_NAMESPACE : activeNamespace;

--- a/src/views/networkpolicies/list/EnableMultiPage.tsx
+++ b/src/views/networkpolicies/list/EnableMultiPage.tsx
@@ -19,9 +19,9 @@ import {
   EmptyStateFooter,
   Tooltip,
 } from '@patternfly/react-core';
-import { ALL_NAMESPACES } from '@utils/constants';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { MultiNetworkPolicyModel } from '@utils/models';
+import { createNamespacePath } from '@utils/utils/helpers';
 import { NetworkConfigModel } from '@views/nads/form/utils/constants';
 
 import '@styles/list-management-group.scss';
@@ -63,7 +63,7 @@ const EnableMultiPage: FC<EnableMultiPageProps> = ({ namespace }) => {
         model: NetworkConfigModel,
         resource: networkClusterConfig,
       });
-      navigate(`/k8s/${namespace || ALL_NAMESPACES}/${modelToRef(MultiNetworkPolicyModel)}`);
+      navigate(`/k8s/${createNamespacePath(namespace)}/${modelToRef(MultiNetworkPolicyModel)}`);
     } catch (apiError) {
       setError(apiError);
     }


### PR DESCRIPTION
This PR fixes a bug where a namespace selected on the networkPolicies tab of the NetworkPolicies page would be reset if the user navigates to the MultiNetworkPolicies tab while MultiNetworkPolicies are disabled and then navigates back to the NetworkPolicies page.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-41605

### Demo

https://github.com/user-attachments/assets/c421d09a-ab2c-4db5-b22a-dff3513414a4


