### PR TITLE
OCPBUGS-54248: Fix empty state Create button links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4425,15 +4425,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
-      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
@@ -15341,32 +15332,6 @@
         "tlds": "^1.199.0"
       }
     },
-    "node_modules/react-redux": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
-      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/use-sync-external-store": "^0.0.6",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.2.25 || ^19",
-        "react": "^18.0 || ^19",
-        "redux": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "redux": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-router": {
       "version": "7.13.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
@@ -15480,15 +15445,6 @@
       "engines": {
         "node": ">= 10.13.0"
       }
-    },
-    "node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",

--- a/src/utils/components/ExternalLink/ExternalLink.tsx
+++ b/src/utils/components/ExternalLink/ExternalLink.tsx
@@ -4,6 +4,7 @@ import { Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 type ExternalLinkProps = {
+  children?: ReactNode;
   className?: string;
   dataTestID?: string;
   href: string;

--- a/src/utils/components/ListEmptyState/ListEmptyState.tsx
+++ b/src/utils/components/ListEmptyState/ListEmptyState.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { Trans } from 'react-i18next';
-import { useNavigate, useParams } from 'react-router';
+import { useNavigate } from 'react-router';
 
 import { K8sResourceCommon, ListPageHeader } from '@openshift-console/dynamic-plugin-sdk';
 import {
@@ -24,7 +24,7 @@ type ListEmptyStateProps<T> = {
   canCreate?: boolean;
   children: ReactNode;
   createButtonAction?: ReactNode;
-  createButtonlink?: string;
+  createButtonLink?: string;
   data: T[];
   error: any;
   kind: string;
@@ -38,7 +38,7 @@ const ListEmptyState = <T extends K8sResourceCommon>({
   canCreate = true,
   children,
   createButtonAction,
-  createButtonlink,
+  createButtonLink,
   data,
   error,
   kind,
@@ -49,7 +49,6 @@ const ListEmptyState = <T extends K8sResourceCommon>({
 }: ListEmptyStateProps<T>) => {
   const { t } = useNetworkingTranslation();
   const navigate = useNavigate();
-  const params = useParams();
 
   if (error) return <ListErrorState error={error} title={title} />;
 
@@ -65,16 +64,7 @@ const ListEmptyState = <T extends K8sResourceCommon>({
 
   const defaultCreateButton = (
     <Button
-      onClick={
-        onCreate
-          ? onCreate
-          : () =>
-              navigate(
-                params?.ns
-                  ? createButtonlink
-                  : `/k8s/ns/default/${params.plural}/${createButtonlink}`,
-              )
-      }
+      onClick={onCreate ? onCreate : () => navigate(createButtonLink)}
       variant={ButtonVariant.primary}
     >
       {t('Create {{ kind }}', { kind })}

--- a/src/views/ingresses/list/IngressesList.tsx
+++ b/src/views/ingresses/list/IngressesList.tsx
@@ -33,6 +33,12 @@ const IngressesList: FC<IngressesListProps> = ({ namespace }) => {
   const navigate = useNavigate();
   const validNamespace = getValidNamespace(namespace || activeNamespace);
 
+  const ingressURL = getResourceURL({
+    activeNamespace: validNamespace,
+    model: IngressModel,
+    path: SHARED_DEFAULT_PATH_NEW_RESOURCE_YAML,
+  });
+
   const [ingress, loaded, loadError] = useK8sWatchResource<IoK8sApiNetworkingV1Ingress[]>({
     groupVersionKind: modelToGroupVersionKind(IngressModel),
     isList: true,
@@ -44,7 +50,7 @@ const IngressesList: FC<IngressesListProps> = ({ namespace }) => {
 
   return (
     <ListEmptyState<IoK8sApiNetworkingV1Ingress>
-      createButtonlink={SHARED_DEFAULT_PATH_NEW_RESOURCE_YAML}
+      createButtonLink={ingressURL}
       data={data}
       error={loadError}
       kind={IngressModel.kind}
@@ -59,15 +65,7 @@ const IngressesList: FC<IngressesListProps> = ({ namespace }) => {
             groupVersionKind: modelToGroupVersionKind(IngressModel),
             namespace: validNamespace,
           }}
-          onClick={() =>
-            navigate(
-              getResourceURL({
-                activeNamespace: validNamespace,
-                model: IngressModel,
-                path: SHARED_DEFAULT_PATH_NEW_RESOURCE_YAML,
-              }),
-            )
-          }
+          onClick={() => navigate(ingressURL)}
         >
           {t('Create Ingress')}
         </ListPageCreateButton>

--- a/src/views/nads/list/NetworkAttachmentDefinitionList.tsx
+++ b/src/views/nads/list/NetworkAttachmentDefinitionList.tsx
@@ -21,7 +21,7 @@ import { documentationURLs, getDocumentationURL } from '@utils/constants/documen
 import { SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM } from '@utils/constants/ui';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { NetworkAttachmentDefinitionKind } from '@utils/resources/nads/types';
-import { resourcePathFromModel } from '@utils/resources/shared';
+import { getResourceURL, resourcePathFromModel } from '@utils/resources/shared';
 import { isEmpty } from '@utils/utils';
 
 import NADListEmpty from './components/NADListEmpty/NADListEmpty';
@@ -57,7 +57,11 @@ const NetworkAttachmentDefinitionList: FC<NetworkAttachmentDefinitionListProps> 
   return (
     <ListEmptyState<NetworkAttachmentDefinitionKind>
       canCreate={canCreateNAD}
-      createButtonlink={SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}
+      createButtonLink={getResourceURL({
+        activeNamespace: namespace,
+        model: NetworkAttachmentDefinitionModel,
+        path: SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM,
+      })}
       data={data}
       error={loadError}
       kind={NetworkAttachmentDefinitionModel.kind}

--- a/src/views/networkpolicies/list/MultiNetworkPolicyList.tsx
+++ b/src/views/networkpolicies/list/MultiNetworkPolicyList.tsx
@@ -16,6 +16,7 @@ import { SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM } from '@utils/constants/ui';
 import usePagination from '@utils/hooks/usePagination/usePagination';
 import { paginationDefaultValues } from '@utils/hooks/usePagination/utils/constants';
 import { MultiNetworkPolicyModel } from '@utils/models';
+import { getResourceURL } from '@utils/resources/shared';
 import { isEmpty } from '@utils/utils';
 
 import NetworkPolicyEmptyState from './components/NetworkPolicyEmptyState';
@@ -44,7 +45,11 @@ const MultiNetworkPolicyList: FC<MultiNetworkPolicyListProps> = ({ namespace }) 
   const paginatedData = filteredData?.slice(pagination.startIndex, pagination.endIndex);
   return (
     <ListEmptyState<IoK8sApiNetworkingV1NetworkPolicy>
-      createButtonlink={SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}
+      createButtonLink={getResourceURL({
+        activeNamespace: namespace,
+        model: MultiNetworkPolicyModel,
+        path: SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM,
+      })}
       data={data}
       error={loadError}
       kind={MultiNetworkPolicyModel.kind}

--- a/src/views/networkpolicies/list/NetworkPolicyList.tsx
+++ b/src/views/networkpolicies/list/NetworkPolicyList.tsx
@@ -17,6 +17,7 @@ import { getNetworkPolicyDocURL } from '@utils/constants/documentation';
 import { SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM } from '@utils/constants/ui';
 import usePagination from '@utils/hooks/usePagination/usePagination';
 import { paginationDefaultValues } from '@utils/hooks/usePagination/utils/constants';
+import { getResourceURL } from '@utils/resources/shared';
 import { isEmpty } from '@utils/utils';
 
 import NetworkPolicyEmptyState from './components/NetworkPolicyEmptyState';
@@ -45,7 +46,11 @@ const NetworkPolicyList: FC<NetworkPolicyListProps> = ({ namespace }) => {
 
   return (
     <ListEmptyState<IoK8sApiNetworkingV1NetworkPolicy>
-      createButtonlink={SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}
+      createButtonLink={getResourceURL({
+        activeNamespace: namespace,
+        model: { ...NetworkPolicyModel, crd: true },
+        path: SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM,
+      })}
       data={data}
       error={loadError}
       kind={NetworkPolicyModel.kind}

--- a/src/views/routes/list/RoutesList.tsx
+++ b/src/views/routes/list/RoutesList.tsx
@@ -54,7 +54,7 @@ const RoutesList: FC<RoutesListProps> = ({ namespace }) => {
 
   return (
     <ListEmptyState<RouteKind>
-      createButtonlink={routeCreateFormLink}
+      createButtonLink={routeCreateFormLink}
       data={routesFetch}
       error={loadError}
       kind={RouteModel.kind}

--- a/src/views/services/list/ServiceList.tsx
+++ b/src/views/services/list/ServiceList.tsx
@@ -15,7 +15,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import ListEmptyState from '@utils/components/ListEmptyState/ListEmptyState';
 import { DOC_URL_NETWORK_SERVICE } from '@utils/constants/documentation';
-import { SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM } from '@utils/constants/ui';
+import { SHARED_DEFAULT_PATH_NEW_RESOURCE_YAML } from '@utils/constants/ui';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { resourcePathFromModel } from '@utils/resources/shared';
 import { getValidNamespace } from '@utils/utils';
@@ -47,13 +47,13 @@ const ServiceList: FC<ServiceListProps> = ({ namespace }) => {
     ServiceModel,
     null,
     validNamespace,
-  )}/${SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}`;
+  )}/${SHARED_DEFAULT_PATH_NEW_RESOURCE_YAML}`;
 
   const title = t('Services');
 
   return (
     <ListEmptyState<IoK8sApiCoreV1Service>
-      createButtonlink={serviceCreateFormLink}
+      createButtonLink={serviceCreateFormLink}
       data={data}
       error={loadError}
       kind={ServiceModel.kind}


### PR DESCRIPTION
This PR fixes the links used for the Create button in the resource list page empty state component.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-54248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed create resource button functionality across multiple resource list views (ingress, network policies, network attachment definitions, routes, services).
  * Corrected component property naming inconsistencies affecting empty state rendering.

* **Refactor**
  * Enhanced link component to support more flexible content rendering options.
  * Improved resource creation URL construction for consistency across list views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->