### PR TITLE
OCPBUGS-81271: Trim subnet input in UDN creation form

### DIFF
--- a/src/views/udns/list/components/UserDefinedNetworkCreateForm.tsx
+++ b/src/views/udns/list/components/UserDefinedNetworkCreateForm.tsx
@@ -65,11 +65,15 @@ const UserDefinedNetworkCreateForm: FC<UserDefinedNetworkCreateFormProps> = ({
               id="input-udn-subnet"
               isRequired
               name="input-udn-subnet"
-              onChange={(_, newValue) =>
-                setValue(subnetField, newValue.split(','), {
+              onChange={(_, newValue) => {
+                const subnets = newValue
+                  ?.split(',')
+                  .map((s) => s.trim())
+                  .filter((s) => s);
+                setValue(subnetField, subnets, {
                   shouldValidate: true,
-                })
-              }
+                });
+              }}
               type="text"
               value={value?.join(',')}
             />


### PR DESCRIPTION
Trim subnet input in the UserDefinedNetwork creation form to avoid error on submit.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-81271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Network creation form: subnet CIDR input now safely handles empty values, trims whitespace, and splits entries cleanly so pasted or comma-separated input is processed correctly while validation remains enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->