### PR TITLE
OCPBUGS-87000: Update Dockerfile.art to 4.22 build image

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,5 +1,5 @@
 # Builder container
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-openshift-4.18 AS build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-openshift-4.22 AS build
 
 # Copy app source
 COPY . /opt/app-root/src/app


### PR DESCRIPTION
Update Dockerfile.art to 4.22 build image to fix failing release builds.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-87000