### PR TITLE
[release-4.22] OCPBUGS-88025: Fix empty state Create button links

### DIFF
--- a/src/utils/components/ExternalLink/ExternalLink.tsx
+++ b/src/utils/components/ExternalLink/ExternalLink.tsx
@@ -4,6 +4,7 @@ import { Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 type ExternalLinkProps = {
+  children?: ReactNode;
   className?: string;
   dataTestID?: string;
   href: string;

--- a/src/utils/components/ListEmptyState/ListEmptyState.tsx
+++ b/src/utils/components/ListEmptyState/ListEmptyState.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { Trans } from 'react-i18next';
-import { useNavigate, useParams } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { K8sResourceCommon, ListPageHeader } from '@openshift-console/dynamic-plugin-sdk';
 import {
@@ -24,7 +24,7 @@ type ListEmptyStateProps<T> = {
   canCreate?: boolean;
   children: ReactNode;
   createButtonAction?: ReactNode;
-  createButtonlink?: string;
+  createButtonLink?: string;
   data: T[];
   error: any;
   kind: string;
@@ -38,7 +38,7 @@ const ListEmptyState = <T extends K8sResourceCommon>({
   canCreate = true,
   children,
   createButtonAction,
-  createButtonlink,
+  createButtonLink,
   data,
   error,
   kind,
@@ -49,7 +49,6 @@ const ListEmptyState = <T extends K8sResourceCommon>({
 }: ListEmptyStateProps<T>) => {
   const { t } = useNetworkingTranslation();
   const navigate = useNavigate();
-  const params = useParams();
 
   if (error) return <ListErrorState error={error} title={title} />;
 
@@ -65,16 +64,7 @@ const ListEmptyState = <T extends K8sResourceCommon>({
 
   const defaultCreateButton = (
     <Button
-      onClick={
-        onCreate
-          ? onCreate
-          : () =>
-              navigate(
-                params?.ns
-                  ? createButtonlink
-                  : `/k8s/ns/default/${params.plural}/${createButtonlink}`,
-              )
-      }
+      onClick={onCreate ? onCreate : () => navigate(createButtonLink)}
       variant={ButtonVariant.primary}
     >
       {t('Create {{ kind }}', { kind })}

--- a/src/views/ingresses/list/IngressesList.tsx
+++ b/src/views/ingresses/list/IngressesList.tsx
@@ -33,6 +33,12 @@ const IngressesList: FC<IngressesListProps> = ({ namespace }) => {
   const navigate = useNavigate();
   const validNamespace = getValidNamespace(namespace || activeNamespace);
 
+  const ingressURL = getResourceURL({
+    activeNamespace: validNamespace,
+    model: { ...IngressModel, crd: true },
+    path: SHARED_DEFAULT_PATH_NEW_RESOURCE_YAML,
+  });
+
   const [ingress, loaded, loadError] = useK8sWatchResource<IoK8sApiNetworkingV1Ingress[]>({
     groupVersionKind: modelToGroupVersionKind(IngressModel),
     isList: true,
@@ -44,7 +50,7 @@ const IngressesList: FC<IngressesListProps> = ({ namespace }) => {
 
   return (
     <ListEmptyState<IoK8sApiNetworkingV1Ingress>
-      createButtonlink={SHARED_DEFAULT_PATH_NEW_RESOURCE_YAML}
+      createButtonLink={ingressURL}
       data={data}
       error={loadError}
       kind={IngressModel.kind}
@@ -59,15 +65,7 @@ const IngressesList: FC<IngressesListProps> = ({ namespace }) => {
             groupVersionKind: modelToGroupVersionKind(IngressModel),
             namespace: validNamespace,
           }}
-          onClick={() =>
-            navigate(
-              getResourceURL({
-                activeNamespace: validNamespace,
-                model: IngressModel,
-                path: SHARED_DEFAULT_PATH_NEW_RESOURCE_YAML,
-              }),
-            )
-          }
+          onClick={() => navigate(ingressURL)}
         >
           {t('Create Ingress')}
         </ListPageCreateButton>

--- a/src/views/nads/list/NetworkAttachmentDefinitionList.tsx
+++ b/src/views/nads/list/NetworkAttachmentDefinitionList.tsx
@@ -21,7 +21,7 @@ import { documentationURLs, getDocumentationURL } from '@utils/constants/documen
 import { SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM } from '@utils/constants/ui';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { NetworkAttachmentDefinitionKind } from '@utils/resources/nads/types';
-import { resourcePathFromModel } from '@utils/resources/shared';
+import { getResourceURL, resourcePathFromModel } from '@utils/resources/shared';
 import { isEmpty } from '@utils/utils';
 
 import NADListEmpty from './components/NADListEmpty/NADListEmpty';
@@ -57,7 +57,11 @@ const NetworkAttachmentDefinitionList: FC<NetworkAttachmentDefinitionListProps> 
   return (
     <ListEmptyState<NetworkAttachmentDefinitionKind>
       canCreate={canCreateNAD}
-      createButtonlink={SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}
+      createButtonLink={getResourceURL({
+        activeNamespace: namespace,
+        model: NetworkAttachmentDefinitionModel,
+        path: SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM,
+      })}
       data={data}
       error={loadError}
       kind={NetworkAttachmentDefinitionModel.kind}

--- a/src/views/networkpolicies/list/MultiNetworkPolicyList.tsx
+++ b/src/views/networkpolicies/list/MultiNetworkPolicyList.tsx
@@ -16,6 +16,7 @@ import { SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM } from '@utils/constants/ui';
 import usePagination from '@utils/hooks/usePagination/usePagination';
 import { paginationDefaultValues } from '@utils/hooks/usePagination/utils/constants';
 import { MultiNetworkPolicyModel } from '@utils/models';
+import { getResourceURL } from '@utils/resources/shared';
 import { isEmpty } from '@utils/utils';
 
 import NetworkPolicyEmptyState from './components/NetworkPolicyEmptyState';
@@ -44,7 +45,11 @@ const MultiNetworkPolicyList: FC<MultiNetworkPolicyListProps> = ({ namespace }) 
   const paginatedData = filteredData?.slice(pagination.startIndex, pagination.endIndex);
   return (
     <ListEmptyState<IoK8sApiNetworkingV1NetworkPolicy>
-      createButtonlink={SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}
+      createButtonLink={getResourceURL({
+        activeNamespace: namespace,
+        model: MultiNetworkPolicyModel,
+        path: SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM,
+      })}
       data={data}
       error={loadError}
       kind={MultiNetworkPolicyModel.kind}

--- a/src/views/networkpolicies/list/NetworkPolicyList.tsx
+++ b/src/views/networkpolicies/list/NetworkPolicyList.tsx
@@ -17,6 +17,7 @@ import { getNetworkPolicyDocURL } from '@utils/constants/documentation';
 import { SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM } from '@utils/constants/ui';
 import usePagination from '@utils/hooks/usePagination/usePagination';
 import { paginationDefaultValues } from '@utils/hooks/usePagination/utils/constants';
+import { getResourceURL } from '@utils/resources/shared';
 import { isEmpty } from '@utils/utils';
 
 import NetworkPolicyEmptyState from './components/NetworkPolicyEmptyState';
@@ -45,7 +46,11 @@ const NetworkPolicyList: FC<NetworkPolicyListProps> = ({ namespace }) => {
 
   return (
     <ListEmptyState<IoK8sApiNetworkingV1NetworkPolicy>
-      createButtonlink={SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}
+      createButtonLink={getResourceURL({
+        activeNamespace: namespace,
+        model: { ...NetworkPolicyModel, crd: true },
+        path: SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM,
+      })}
       data={data}
       error={loadError}
       kind={NetworkPolicyModel.kind}

--- a/src/views/routes/list/RoutesList.tsx
+++ b/src/views/routes/list/RoutesList.tsx
@@ -54,7 +54,7 @@ const RoutesList: FC<RoutesListProps> = ({ namespace }) => {
 
   return (
     <ListEmptyState<RouteKind>
-      createButtonlink={routeCreateFormLink}
+      createButtonLink={routeCreateFormLink}
       data={routesFetch}
       error={loadError}
       kind={RouteModel.kind}

--- a/src/views/services/list/ServiceList.tsx
+++ b/src/views/services/list/ServiceList.tsx
@@ -15,7 +15,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import ListEmptyState from '@utils/components/ListEmptyState/ListEmptyState';
 import { DOC_URL_NETWORK_SERVICE } from '@utils/constants/documentation';
-import { SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM } from '@utils/constants/ui';
+import { SHARED_DEFAULT_PATH_NEW_RESOURCE_YAML } from '@utils/constants/ui';
 import { useNetworkingTranslation } from '@utils/hooks/useNetworkingTranslation';
 import { resourcePathFromModel } from '@utils/resources/shared';
 import { getValidNamespace } from '@utils/utils';
@@ -47,13 +47,13 @@ const ServiceList: FC<ServiceListProps> = ({ namespace }) => {
     ServiceModel,
     null,
     validNamespace,
-  )}/${SHARED_DEFAULT_PATH_NEW_RESOURCE_FORM}`;
+  )}/${SHARED_DEFAULT_PATH_NEW_RESOURCE_YAML}`;
 
   const title = t('Services');
 
   return (
     <ListEmptyState<IoK8sApiCoreV1Service>
-      createButtonlink={serviceCreateFormLink}
+      createButtonLink={serviceCreateFormLink}
       data={data}
       error={loadError}
       kind={ServiceModel.kind}


### PR DESCRIPTION
This PR fixes the links used for the Create button in the resource list page empty state component.

Manual backport of https://github.com/openshift/networking-console-plugin/pull/423

Jira: https://redhat.atlassian.net/browse/OCPBUGS-88025