### PR TITLE
[release-4.21] OCPBUGS-88313: Trim subnet input in UDN creation form

### DIFF
--- a/src/views/udns/list/components/UserDefinedNetworkCreateForm.tsx
+++ b/src/views/udns/list/components/UserDefinedNetworkCreateForm.tsx
@@ -65,11 +65,15 @@ const UserDefinedNetworkCreateForm: FC<UserDefinedNetworkCreateFormProps> = ({
               id="input-udn-subnet"
               isRequired
               name="input-udn-subnet"
-              onChange={(_, newValue) =>
-                setValue(subnetField, newValue.split(','), {
+              onChange={(_, newValue) => {
+                const subnets = newValue
+                  ?.split(',')
+                  .map((s) => s.trim())
+                  .filter((s) => s);
+                setValue(subnetField, subnets, {
                   shouldValidate: true,
-                })
-              }
+                });
+              }}
               type="text"
               value={value?.join(',')}
             />


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/OCPBUGS-88313

Cherry-pick of #425 to release-4.21.

Trim subnet input in the UserDefinedNetwork creation form to avoid CIDR validation error when whitespace is present.