### PR TITLE
[release-4.18] OCPBUGS-41880: Fix namespace retention between NetworkPolicies tabs when MultiNetworkPolicies are disabled

### DIFF
--- a/src/utils/utils/helpers.ts
+++ b/src/utils/utils/helpers.ts
@@ -15,7 +15,7 @@ export const generateName = (prefix: string): string => {
 };
 
 export const createNamespacePath = (namespace: string) =>
-  namespace ? `ns/${namespace}` : ALL_NAMESPACES;
+  namespace === ALL_NAMESPACES || !namespace ? ALL_NAMESPACES : `ns/${namespace}`;
 
 export const getValidNamespace = (activeNamespace: string) =>
   activeNamespace === ALL_NAMESPACES_KEY ? DEFAULT_NAMESPACE : activeNamespace;

--- a/src/views/networkpolicies/list/NetworkPolicyPage.tsx
+++ b/src/views/networkpolicies/list/NetworkPolicyPage.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useMemo } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate, useParams } from 'react-router-dom-v5-compat';
 
 import { modelToGroupVersionKind, NetworkPolicyModel } from '@kubevirt-ui/kubevirt-api/console';
 import { ListPageCreateButton, ListPageHeader } from '@openshift-console/dynamic-plugin-sdk';
@@ -21,9 +21,13 @@ export type NetworkPolicyPageNavProps = {
   namespace: string;
 };
 
-const NetworkPolicyPage: FC<NetworkPolicyPageNavProps> = ({ namespace }) => {
+const NetworkPolicyPage: FC<NetworkPolicyPageNavProps> = ({ namespace: namespaceProp }) => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { ns } = useParams<{ ns?: string }>();
+
+  // Use namespace from route params if available (for custom RoutePage), otherwise use prop
+  const namespace = ns || namespaceProp;
 
   const locationTabKey = useMemo(
     () => getActiveKeyFromPathname(location?.pathname),

--- a/src/views/networkpolicies/list/utils.ts
+++ b/src/views/networkpolicies/list/utils.ts
@@ -1,6 +1,6 @@
 import { modelToRef, NetworkPolicyModel } from '@kubevirt-ui/kubevirt-api/console';
-import { ALL_NAMESPACES } from '@utils/constants';
 import { MultiNetworkPolicyModel } from '@utils/models';
+import { createNamespacePath } from '@utils/utils/helpers';
 
 import { TAB_INDEXES } from './constants';
 
@@ -13,7 +13,7 @@ export const getActiveKeyFromPathname = (pathname: string) => {
 };
 
 export const getNetworkPolicyURLTab = (tabIndex: number | string, namespace: string): string => {
-  const namespacePath = namespace === ALL_NAMESPACES ? namespace : `ns/${namespace}`;
+  const namespacePath = createNamespacePath(namespace);
 
   if (tabIndex === TAB_INDEXES.ENABLE_MULTI) {
     return `/k8s/${namespacePath}/${modelToRef(NetworkPolicyModel)}/enable-multi`;


### PR DESCRIPTION
Fix namespace retention between NetworkPolicies tabs when MultiNetworkPolicies are disabled.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-41880

Demo:

https://github.com/user-attachments/assets/9d84d7c0-c129-4588-937e-9847a31bacd5

