### PR TITLE
OCPBUGS-42124: Fix 'model does not exist' error when enabling MultiNetworkPolicies

### DIFF
--- a/src/views/networkpolicies/list/EnableMultiPage.tsx
+++ b/src/views/networkpolicies/list/EnableMultiPage.tsx
@@ -50,12 +50,12 @@ const EnableMultiPage: FC<EnableMultiPageProps> = ({ namespace }) => {
       await k8sPatch({
         data: [
           {
-            op: 'replace',
+            op: 'add',
             path: '/spec/disableMultiNetwork',
             value: false,
           },
           {
-            op: 'replace',
+            op: 'add',
             path: '/spec/useMultiNetworkPolicy',
             value: true,
           },


### PR DESCRIPTION
Fix 'model does not exist' error when enabling MultiNetworkPolicies for the first time on a given namespace.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-42124

## Demo:

https://github.com/user-attachments/assets/c5230f9b-561a-4b95-8065-2e6f30e997a5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with multi-network policy configuration settings to ensure they are properly updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->