### PR TITLE
NO-JIRA: Use page insets in NetworkPolicies page

### DIFF
--- a/src/views/networkpolicies/list/NetworkPolicyPage.tsx
+++ b/src/views/networkpolicies/list/NetworkPolicyPage.tsx
@@ -66,6 +66,7 @@ const NetworkPolicyPage: FC = () => {
           navigate(getNetworkPolicyURLTab(tabIndex, namespace || ALL_NAMESPACES));
         }}
         unmountOnExit
+        usePageInsets
       >
         <Tab
           eventKey={TAB_INDEXES.NETWORK}


### PR DESCRIPTION
aligns with other console pages which use page insets when tabs are used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing and alignment around the Network Policies tabbed layout for a more consistent page appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->