### PR TITLE
chore(i18n): add Cursor Memsource skill and peer usage guide

### DIFF
--- a/.cursor/skills/i18n-memsource/SKILL.md
+++ b/.cursor/skills/i18n-memsource/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: i18n-memsource
+description: >-
+  Automates the Memsource/Phrase i18n translation workflow for networking-console-plugin.
+  Use when the user asks to upload translations, download translations, check translation
+  status, memsource upload, memsource download, i18n upload, i18n download, send for
+  translation, or get translations.
+---
+
+# networking-console-plugin i18n Memsource Workflow
+
+Manages upload/download of translations to Phrase (Memsource) for this repo.
+
+Uses the **existing** local `i18n-scripts/` + `i18next-parser` setup.
+Does **not** use `ocp-plugin-i18n-scripts` or `i18next-cli`.
+
+For a peer-oriented walkthrough, see [USAGE.md](./USAGE.md).
+
+## State
+
+Read and update `.cursor/skills/i18n-memsource/state.json` after each upload.
+
+## Plugin config
+
+| Field | Value |
+|-------|-------|
+| Namespace / locale file | `plugin__networking-console-plugin` |
+| Memsource template ID | `zBOwr4BxYwEq7xlJ37c1F3` |
+| Project title | `[OCP $VERSION] UI Localization networking-console-plugin - Sprint $SPRINT/Branch $BRANCH` |
+| Languages | `ja`, `zh-cn`, `ko`, `fr`, `es` |
+| Locale dirs on disk | `en`, `es`, `fr`, `ja`, `ko`, **`zh`** (not `zh-cn`) |
+| PO filename pattern | `po-files/<lang>/plugin__networking-console-plugin.po` |
+
+## Prerequisites
+
+### Memsource CLI
+
+```bash
+MEMSOURCE_BIN=$(python3 -c "import shutil; print(shutil.which('memsource') or '')")
+if [ -z "$MEMSOURCE_BIN" ]; then
+  MEMSOURCE_BIN=$(find "$HOME/Library/Python" -name memsource -type f 2>/dev/null | head -1)
+fi
+export PATH="$(dirname "$MEMSOURCE_BIN"):$PATH"
+```
+
+### Authentication
+
+Credentials live in `~/.memsourcerc`. Capture a token so npm child processes inherit auth:
+
+```bash
+source ~/.memsourcerc
+export MEMSOURCE_TOKEN=$(memsource auth login \
+  --user-name "$MEMSOURCE_USERNAME" \
+  --password "$MEMSOURCE_PASSWORD" \
+  -f json \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+
+if [ -z "$MEMSOURCE_TOKEN" ]; then
+  echo "ERROR: Memsource authentication failed. Check ~/.memsourcerc credentials."
+  return 1
+fi
+
+memsource auth whoami
+```
+
+Run this once at the start of every action. Do not ask the user to authenticate manually.
+
+---
+
+## Critical nuances
+
+### 1. zh-cn vs zh filesystem mismatch
+
+`i18n-scripts/languages.sh` uses `zh-cn`, but locales live under `locales/zh/`.
+Without a symlink, `i18n-to-po` cannot merge existing Chinese translations and
+uploads empty msgstr for Chinese.
+
+**Before any `export-pos` during upload:**
+
+```bash
+ln -sfn zh locales/zh-cn
+```
+
+Remove after upload finishes. Download already maps `zh-cn` → `zh`.
+
+### 2. PO generation preserves existing translations
+
+`i18n-to-po.js`:
+
+1. Start from English keys in `locales/en/`
+2. Clear values (empty placeholders)
+3. Merge existing values from `locales/<lang>/`
+4. Convert to PO via `i18next-conv`
+
+Never skip `export-pos` or hand-build English-only POs.
+
+### 3. English leak detection
+
+`i18next-parser` + `useKeysAsDefaultValue: true` can leave English in secondary
+locale JSON. After `export-pos`, flag msgstr identical to msgid.
+
+### 4. Download clean-git check is wrong
+
+`memsource-download.sh` checks `public/locales` / `packages/**/locales`, but this
+repo uses root `locales/`. Before download, verify:
+
+```bash
+git status --short --untracked-files -- locales/
+```
+
+---
+
+## Action 1: Upload Translations
+
+Trigger: "upload translations", "memsource upload", "i18n upload", "send for translation"
+
+### Checklist
+
+```
+Upload Progress:
+- [ ] Step 1: Load state
+- [ ] Step 2: Get VERSION from user, auto-increment SPRINT
+- [ ] Step 3: Authenticate with Memsource
+- [ ] Step 4: Extract translation keys
+- [ ] Step 5: Create zh-cn symlink and generate PO files
+- [ ] Step 6: Validate PO files
+- [ ] Step 7: Show summary and get approval
+- [ ] Step 8: Upload to Memsource
+- [ ] Step 9: Cleanup and update state
+```
+
+### Step 1: Load state
+
+Read `.cursor/skills/i18n-memsource/state.json`.
+
+### Step 2: Get VERSION and SPRINT
+
+- Always ask the user for VERSION. Do not assume.
+- Auto-increment SPRINT from state (previous + 1).
+- Show: "Uploading VERSION X, Sprint Y (branch: Z)"
+
+```bash
+git branch --show-current
+```
+
+### Step 3: Authenticate
+
+Run the Prerequisites auth sequence and `memsource auth whoami`.
+
+### Step 4: Extract translation keys
+
+```bash
+npm run i18n
+# → ./i18n-scripts/build-i18n.sh && node ./i18n-scripts/set-english-defaults.js
+```
+
+Then show:
+
+```bash
+git status --short -- locales/
+git diff --stat -- locales/
+```
+
+Require approval if the locale diff looks wrong.
+
+### Step 5: zh-cn symlink + export POs
+
+```bash
+ln -sfn zh locales/zh-cn
+rm -rf po-files
+npm run export-pos
+```
+
+Keep the symlink until after Step 8 (`memsource-upload` re-runs `export-pos`).
+
+### Step 6: Validate PO files
+
+For each of `ja`, `zh-cn`, `ko`, `fr`, `es`:
+
+```bash
+for lang in ja zh-cn ko fr es; do
+  echo -n "$lang keys: "
+  rg -c '^msgid "' po-files/$lang/*.po 2>/dev/null || echo "0"
+done
+
+for lang in ja zh-cn ko fr es; do
+  echo "=== $lang ==="
+  python3 -c "
+import re, glob, sys
+files = glob.glob(f'po-files/{sys.argv[1]}/*.po')
+content = ''.join(open(f).read() for f in files)
+entries = re.findall(r'msgid \"((?:\\\\.|[^\"])*)\"\s*msgstr \"((?:\\\\.|[^\"])*)\"', content)
+# skip header empty msgid
+entries = [(a,b) for a,b in entries if a]
+translated = sum(1 for a,b in entries if b and b != a)
+leaks = sum(1 for a,b in entries if b and b == a)
+new = sum(1 for a,b in entries if not b)
+print(f'  total={len(entries)} translated={translated} new={new} english_leaks={leaks}')
+" "$lang"
+done
+```
+
+### Step 7: Show summary and get approval
+
+Present plugin, version, sprint, branch, validation results, and project title.
+Ask for explicit approval before upload.
+
+### Step 8: Upload to Memsource
+
+```bash
+npm run memsource-upload -- -v "$VERSION" -s "$SPRINT"
+```
+
+Capture `PROJECT_ID` (`.uid`) from `memsource project create` output.
+
+### Step 9: Cleanup and update state
+
+```bash
+rm -f locales/zh-cn
+rm -rf po-files locales/tmp
+```
+
+Update `state.json` with `version`, `sprint`, `lastProjectId`, `memsourceProjectUrl`, and history.
+
+Draft notification:
+
+```
+Subject: [OCP VERSION] Translation Upload - networking-console-plugin Sprint SPRINT
+
+Hi Localization Team,
+
+New translation strings have been uploaded for networking-console-plugin
+(OCP VERSION, Sprint SPRINT).
+
+Memsource project: https://cloud.memsource.com/web/project2/show/PROJECT_ID
+
+Languages: ja, zh-cn, ko, fr, es
+Total keys: N
+
+Please review and translate at your convenience. Let us know when translations
+are ready for download.
+
+Thanks
+```
+
+---
+
+## Action 2: Download Translations
+
+Trigger: "download translations", "memsource download", "i18n download", "get translations"
+
+### Checklist
+
+```
+Download Progress:
+- [ ] Step 1: Load state / confirm PROJECT_ID
+- [ ] Step 2: Authenticate
+- [ ] Step 3: Check translation status
+- [ ] Step 4: Ensure locales/ is clean
+- [ ] Step 5: Download translations
+- [ ] Step 6: Show diff summary
+- [ ] Step 7: Create PR (optional)
+```
+
+### Step 1: Confirm PROJECT_ID
+
+Show `lastProjectId` from state; ask to confirm or override.
+
+### Step 2: Authenticate
+
+Same auth sequence as upload.
+
+### Step 3: Status
+
+```bash
+for lang in ja zh-cn ko fr es; do
+  memsource job list \
+    --project-id "$PROJECT_ID" \
+    --target-lang "$lang" \
+    -f json \
+    -c uid,status,targetLang
+done
+```
+
+Warn if not all completed; ask before proceeding.
+
+### Step 4: Clean locales
+
+```bash
+git status --short --untracked-files -- locales/
+# Must be clean — commit or stash first
+```
+
+### Step 5: Download
+
+```bash
+npm run memsource-download -- -p "$PROJECT_ID"
+```
+
+This downloads POs, converts with `po-to-i18n` (`zh-cn` → `zh`), and auto-commits.
+
+### Step 6–7: Diff + optional PR
+
+```bash
+git diff HEAD~1 --stat -- locales/
+
+git checkout -b "chore/i18n-update-sprint-${SPRINT}"
+git push -u origin HEAD
+gh pr create --title "chore(i18n): update translations for Sprint ${SPRINT}" --body "$(cat <<EOF
+## Summary
+- Downloaded translations from Memsource project ${PROJECT_ID}
+- Languages: ja, zh-cn, ko, fr, es
+
+## Memsource Project
+https://cloud.memsource.com/web/project2/show/${PROJECT_ID}
+
+## Test plan
+- [ ] Verify locale files are valid JSON
+- [ ] Spot-check translations in the UI
+
+Resolves: None
+EOF
+)"
+```
+
+---
+
+## Action 3: Status only
+
+1. Load `lastProjectId` (confirm/override)
+2. Authenticate
+3. Run job list for each language
+4. If all completed, suggest download
+
+---
+
+## Important reminders
+
+- Always symlink `locales/zh-cn` → `zh` before upload `export-pos`; remove after upload
+- Never skip `export-pos`
+- Validate English leaks before upload
+- Clean root `locales/` before download
+- Update `state.json` after successful upload

--- a/.cursor/skills/i18n-memsource/SKILL.md
+++ b/.cursor/skills/i18n-memsource/SKILL.md
@@ -80,12 +80,17 @@ Also ensure `jq` is installed (`brew install jq`) — upload scripts need it.
 Without a symlink, `i18n-to-po` cannot merge existing Chinese translations and
 uploads empty msgstr for Chinese.
 
-**Before any `export-pos` during upload**, create the symlink and register
-unconditional cleanup (also on failure / cancel):
+**Before any `export-pos` during upload**, register cleanup first, then create
+the symlink (also cleans up on failure / cancel). Do not overwrite a
+pre-existing non-symlink `locales/zh-cn`:
 
 ```bash
-ln -sfn zh locales/zh-cn
 trap 'rm -f locales/zh-cn; rm -rf po-files locales/tmp' EXIT
+if [ -e locales/zh-cn ] && [ ! -L locales/zh-cn ]; then
+  echo "ERROR: locales/zh-cn exists and is not a symlink; resolve manually"
+  exit 1
+fi
+ln -sfn zh locales/zh-cn
 ```
 
 Download already maps `zh-cn` → `zh`.
@@ -116,8 +121,9 @@ may treat as already translated.
 | English placeholder (== English source) | **Empty** (needs translation) |
 
 `export-pos.sh` runs `i18n-scripts/clear-english-msgstr.js` after generating POs
-to clear `msgstr` when it equals `msgid`. Because `memsource-upload.sh` re-runs
-`export-pos`, that clear also applies to the files that get uploaded.
+to clear `msgstr` when it equals `msgid`. `memsource-upload.sh` re-runs the same
+`export-pos` pipeline before creating jobs, so Step 6 validation is of the same
+artifacts the upload script regenerates (not a different code path).
 
 This clear step is **redundant** if the repo migrates to
 [`ocp-plugin-i18n-scripts`](https://github.com/avivtur/ocp-plugin-i18n-scripts),
@@ -192,15 +198,19 @@ Require approval if the locale diff looks wrong.
 ### Step 5: zh-cn symlink + export POs + clear English msgstr
 
 ```bash
-ln -sfn zh locales/zh-cn
 trap 'rm -f locales/zh-cn; rm -rf po-files locales/tmp' EXIT
+if [ -e locales/zh-cn ] && [ ! -L locales/zh-cn ]; then
+  echo "ERROR: locales/zh-cn exists and is not a symlink; resolve manually"
+  exit 1
+fi
+ln -sfn zh locales/zh-cn
 rm -rf po-files
 npm run export-pos
 # export-pos ends with: node ./i18n-scripts/clear-english-msgstr.js
 ```
 
-Keep the symlink until after Step 8 (`memsource-upload` re-runs `export-pos`,
-which also re-runs the clear step). The `trap` ensures cleanup even if a later
+Keep the symlink until after Step 8 (`memsource-upload` re-runs the same
+`export-pos` + clear pipeline). The `trap` ensures cleanup even if a later
 step fails.
 
 If validating a hand-run export that skipped the script hook:
@@ -223,6 +233,8 @@ for lang in ja zh-cn ko fr es; do
   python3 -c "
 import re, glob, sys
 files = glob.glob(f'po-files/{sys.argv[1]}/*.po')
+if not files:
+  raise SystemExit(f'missing PO files for {sys.argv[1]}')
 content = ''.join(open(f).read() for f in files)
 entries = re.findall(r'msgid \"((?:\\\\.|[^\"])*)\"\s*msgstr \"((?:\\\\.|[^\"])*)\"', content)
 entries = [(a,b) for a,b in entries if a]
@@ -230,11 +242,13 @@ translated = sum(1 for a,b in entries if b and b != a)
 needs = sum(1 for a,b in entries if not b)
 leaks = sum(1 for a,b in entries if b and b == a)
 print(f'  total={len(entries)} translated={translated} needs_translation={needs} english_leaks_remaining={leaks}')
+if leaks:
+  raise SystemExit('english_leaks_remaining must be 0')
 " "$lang"
 done
 ```
 
-Warn if `english_leaks_remaining > 0`.
+Stop the upload if any language is missing POs or has `english_leaks_remaining > 0`.
 
 ### Step 7: Show summary and get approval
 
@@ -247,7 +261,9 @@ Ask for explicit approval before upload.
 npm run memsource-upload -- -v "$VERSION" -s "$SPRINT"
 ```
 
-Capture `PROJECT_ID` (`.uid`) from `memsource project create` output.
+Capture `PROJECT_ID` (`.uid`) from `memsource project create` output. If the
+command fails after project creation, persist that ID (or delete the orphan in
+Phrase) before retrying — otherwise a retry creates another project.
 
 ### Step 9: Cleanup and update state
 

--- a/.cursor/skills/i18n-memsource/SKILL.md
+++ b/.cursor/skills/i18n-memsource/SKILL.md
@@ -94,10 +94,27 @@ Remove after upload finishes. Download already maps `zh-cn` → `zh`.
 
 Never skip `export-pos` or hand-build English-only POs.
 
-### 3. English leak detection
+### 3. English placeholders must be empty in uploaded POs
 
-`i18next-parser` + `useKeysAsDefaultValue: true` can leave English in secondary
-locale JSON. After `export-pos`, flag msgstr identical to msgid.
+`i18next-parser` + `useKeysAsDefaultValue: true` can leave English text in
+secondary locale JSON. Old `i18n-to-po` copies that into `msgstr`, which Phrase
+may treat as already translated.
+
+**Desired PO state before upload:**
+
+| Locale JSON value | msgstr in PO |
+|-------------------|--------------|
+| Real non-English translation | Keep it (carry forward) |
+| Empty `""` | Empty (needs translation) |
+| English placeholder (== English source) | **Empty** (needs translation) |
+
+`export-pos.sh` runs `i18n-scripts/clear-english-msgstr.js` after generating POs
+to clear `msgstr` when it equals `msgid`. Because `memsource-upload.sh` re-runs
+`export-pos`, that clear also applies to the files that get uploaded.
+
+This clear step is **redundant** if the repo migrates to
+[`ocp-plugin-i18n-scripts`](https://github.com/avivtur/ocp-plugin-i18n-scripts),
+which filters English placeholders during PO generation.
 
 ### 4. Download clean-git check is wrong
 
@@ -122,7 +139,7 @@ Upload Progress:
 - [ ] Step 2: Get VERSION from user, auto-increment SPRINT
 - [ ] Step 3: Authenticate with Memsource
 - [ ] Step 4: Extract translation keys
-- [ ] Step 5: Create zh-cn symlink and generate PO files
+- [ ] Step 5: Create zh-cn symlink, generate PO files, clear English msgstr
 - [ ] Step 6: Validate PO files
 - [ ] Step 7: Show summary and get approval
 - [ ] Step 8: Upload to Memsource
@@ -163,26 +180,33 @@ git diff --stat -- locales/
 
 Require approval if the locale diff looks wrong.
 
-### Step 5: zh-cn symlink + export POs
+### Step 5: zh-cn symlink + export POs + clear English msgstr
 
 ```bash
 ln -sfn zh locales/zh-cn
 rm -rf po-files
 npm run export-pos
+# export-pos ends with: node ./i18n-scripts/clear-english-msgstr.js
 ```
 
-Keep the symlink until after Step 8 (`memsource-upload` re-runs `export-pos`).
+Keep the symlink until after Step 8 (`memsource-upload` re-runs `export-pos`,
+which also re-runs the clear step).
+
+If validating a hand-run export that skipped the script hook:
+
+```bash
+node ./i18n-scripts/clear-english-msgstr.js
+```
 
 ### Step 6: Validate PO files
 
-For each of `ja`, `zh-cn`, `ko`, `fr`, `es`:
+After the clear step, English placeholders should be empty. Report:
+
+- **translated** = non-empty msgstr and msgstr ≠ msgid (real carry-forward)
+- **needs translation** = empty msgstr (includes former English placeholders)
+- **english_leaks remaining** = msgstr == msgid (should be 0 after clear)
 
 ```bash
-for lang in ja zh-cn ko fr es; do
-  echo -n "$lang keys: "
-  rg -c '^msgid "' po-files/$lang/*.po 2>/dev/null || echo "0"
-done
-
 for lang in ja zh-cn ko fr es; do
   echo "=== $lang ==="
   python3 -c "
@@ -190,15 +214,16 @@ import re, glob, sys
 files = glob.glob(f'po-files/{sys.argv[1]}/*.po')
 content = ''.join(open(f).read() for f in files)
 entries = re.findall(r'msgid \"((?:\\\\.|[^\"])*)\"\s*msgstr \"((?:\\\\.|[^\"])*)\"', content)
-# skip header empty msgid
 entries = [(a,b) for a,b in entries if a]
 translated = sum(1 for a,b in entries if b and b != a)
+needs = sum(1 for a,b in entries if not b)
 leaks = sum(1 for a,b in entries if b and b == a)
-new = sum(1 for a,b in entries if not b)
-print(f'  total={len(entries)} translated={translated} new={new} english_leaks={leaks}')
+print(f'  total={len(entries)} translated={translated} needs_translation={needs} english_leaks_remaining={leaks}')
 " "$lang"
 done
 ```
+
+Warn if `english_leaks_remaining > 0`.
 
 ### Step 7: Show summary and get approval
 
@@ -337,7 +362,8 @@ EOF
 ## Important reminders
 
 - Always symlink `locales/zh-cn` → `zh` before upload `export-pos`; remove after upload
-- Never skip `export-pos`
-- Validate English leaks before upload
+- Never skip `export-pos` (it preserves real translations and clears English placeholders)
+- After export, `needs_translation` should cover empty msgstr; `english_leaks_remaining` should be 0
 - Clean root `locales/` before download
 - Update `state.json` after successful upload
+- If this repo migrates to `ocp-plugin-i18n-scripts`, remove `clear-english-msgstr.js` from `export-pos.sh` (redundant)

--- a/.cursor/skills/i18n-memsource/SKILL.md
+++ b/.cursor/skills/i18n-memsource/SKILL.md
@@ -43,27 +43,32 @@ fi
 export PATH="$(dirname "$MEMSOURCE_BIN"):$PATH"
 ```
 
-### Authentication
+### Authentication (credentials stay with the user)
 
-Credentials live in `~/.memsourcerc`. Capture a token so npm child processes inherit auth:
+**Do not** read `~/.memsourcerc`, Memsource passwords, or long-lived tokens into
+the agent context. Phrase is a paid external service — treat credentials like
+any other secret.
+
+Preferred flow:
+
+1. Ask the user to authenticate in **their own terminal** and confirm
+   `memsource auth whoami` works (and that `MEMSOURCE_TOKEN` is exported in the
+   shell they will use for `npm run memsource-*`).
+2. The agent may run extract/export/validation without credentials.
+3. For upload/download/status, either:
+   - the user runs the `memsource-*` commands themselves after the agent prepares
+     artifacts, or
+   - the user has already exported a **short-lived** `MEMSOURCE_TOKEN` in the
+     shared shell (never paste the password into chat).
+
+If a shared shell already has `MEMSOURCE_TOKEN`, verify with:
 
 ```bash
-source ~/.memsourcerc
-export MEMSOURCE_TOKEN=$(memsource auth login \
-  --user-name "$MEMSOURCE_USERNAME" \
-  --password "$MEMSOURCE_PASSWORD" \
-  -f json \
-  | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
-
-if [ -z "$MEMSOURCE_TOKEN" ]; then
-  echo "ERROR: Memsource authentication failed. Check ~/.memsourcerc credentials."
-  return 1
-fi
-
 memsource auth whoami
 ```
 
-Run this once at the start of every action. Do not ask the user to authenticate manually.
+If auth fails, stop and ask the user to refresh the token outside the agent.
+Also ensure `jq` is installed (`brew install jq`) — upload scripts need it.
 
 ---
 
@@ -75,13 +80,15 @@ Run this once at the start of every action. Do not ask the user to authenticate 
 Without a symlink, `i18n-to-po` cannot merge existing Chinese translations and
 uploads empty msgstr for Chinese.
 
-**Before any `export-pos` during upload:**
+**Before any `export-pos` during upload**, create the symlink and register
+unconditional cleanup (also on failure / cancel):
 
 ```bash
 ln -sfn zh locales/zh-cn
+trap 'rm -f locales/zh-cn; rm -rf po-files locales/tmp' EXIT
 ```
 
-Remove after upload finishes. Download already maps `zh-cn` → `zh`.
+Download already maps `zh-cn` → `zh`.
 
 ### 2. PO generation preserves existing translations
 
@@ -133,16 +140,16 @@ Trigger: "upload translations", "memsource upload", "i18n upload", "send for tra
 
 ### Checklist
 
-```
+```text
 Upload Progress:
 - [ ] Step 1: Load state
 - [ ] Step 2: Get VERSION from user, auto-increment SPRINT
-- [ ] Step 3: Authenticate with Memsource
+- [ ] Step 3: Confirm user-provided Memsource auth (no credential access)
 - [ ] Step 4: Extract translation keys
 - [ ] Step 5: Create zh-cn symlink, generate PO files, clear English msgstr
 - [ ] Step 6: Validate PO files
 - [ ] Step 7: Show summary and get approval
-- [ ] Step 8: Upload to Memsource
+- [ ] Step 8: Upload to Memsource (user shell / short-lived token only)
 - [ ] Step 9: Cleanup and update state
 ```
 
@@ -160,9 +167,11 @@ Read `.cursor/skills/i18n-memsource/state.json`.
 git branch --show-current
 ```
 
-### Step 3: Authenticate
+### Step 3: Confirm authentication
 
-Run the Prerequisites auth sequence and `memsource auth whoami`.
+Do **not** source `~/.memsourcerc` or request the password in chat. Ask the user
+to authenticate in their terminal, then verify `memsource auth whoami` in the
+shell that will run upload (or have the user run Step 8 themselves).
 
 ### Step 4: Extract translation keys
 
@@ -184,13 +193,15 @@ Require approval if the locale diff looks wrong.
 
 ```bash
 ln -sfn zh locales/zh-cn
+trap 'rm -f locales/zh-cn; rm -rf po-files locales/tmp' EXIT
 rm -rf po-files
 npm run export-pos
 # export-pos ends with: node ./i18n-scripts/clear-english-msgstr.js
 ```
 
 Keep the symlink until after Step 8 (`memsource-upload` re-runs `export-pos`,
-which also re-runs the clear step).
+which also re-runs the clear step). The `trap` ensures cleanup even if a later
+step fails.
 
 If validating a hand-run export that skipped the script hook:
 
@@ -249,7 +260,7 @@ Update `state.json` with `version`, `sprint`, `lastProjectId`, `memsourceProject
 
 Draft notification:
 
-```
+```text
 Subject: [OCP VERSION] Translation Upload - networking-console-plugin Sprint SPRINT
 
 Hi Localization Team,
@@ -276,10 +287,10 @@ Trigger: "download translations", "memsource download", "i18n download", "get tr
 
 ### Checklist
 
-```
+```text
 Download Progress:
 - [ ] Step 1: Load state / confirm PROJECT_ID
-- [ ] Step 2: Authenticate
+- [ ] Step 2: Confirm user-provided Memsource auth
 - [ ] Step 3: Check translation status
 - [ ] Step 4: Ensure locales/ is clean
 - [ ] Step 5: Download translations
@@ -291,9 +302,9 @@ Download Progress:
 
 Show `lastProjectId` from state; ask to confirm or override.
 
-### Step 2: Authenticate
+### Step 2: Confirm authentication
 
-Same auth sequence as upload.
+Same as upload Step 3 — user-owned credentials only; no `~/.memsourcerc` in agent context.
 
 ### Step 3: Status
 

--- a/.cursor/skills/i18n-memsource/USAGE.md
+++ b/.cursor/skills/i18n-memsource/USAGE.md
@@ -110,51 +110,62 @@ export MEMSOURCE_TOKEN=$(memsource auth login \
 npm run i18n
 git diff --stat -- locales/   # review before continuing
 
-# CRITICAL: without this, Chinese existing translations are lost on upload
-ln -sfn zh locales/zh-cn
+# CRITICAL: register cleanup BEFORE creating the symlink
 trap 'rm -f locales/zh-cn; rm -rf po-files locales/tmp' EXIT
+if [ -e locales/zh-cn ] && [ ! -L locales/zh-cn ]; then
+  echo "ERROR: locales/zh-cn exists and is not a symlink; resolve manually"
+  exit 1
+fi
+ln -sfn zh locales/zh-cn
 
 rm -rf po-files
 npm run export-pos
 # export-pos also runs clear-english-msgstr.js so msgstr==msgid becomes empty
-# validate: translated vs needs_translation; english_leaks_remaining should be 0
+# validate the same export-pos pipeline memsource-upload will re-run
+# (translated vs needs_translation; english_leaks_remaining should be 0)
 for lang in ja zh-cn ko fr es; do
   echo "=== $lang ==="
   python3 -c "
 import re, glob, sys
 files = glob.glob(f'po-files/{sys.argv[1]}/*.po')
+if not files:
+  raise SystemExit(f'missing PO files for {sys.argv[1]}')
 content = ''.join(open(f).read() for f in files)
 entries = [(a,b) for a,b in re.findall(r'msgid \"(.*?)\"\nmsgstr \"(.*?)\"', content) if a]
 translated = sum(1 for a,b in entries if b and b != a)
 needs = sum(1 for a,b in entries if not b)
 leaks = sum(1 for a,b in entries if b and b == a)
 print(f'total={len(entries)} translated={translated} needs_translation={needs} english_leaks_remaining={leaks}')
+if leaks:
+  raise SystemExit('english_leaks_remaining must be 0')
 " "$lang"
 done
 
-VERSION=5.0.0   # set from release / ask user
-SPRINT=1        # previous state.sprint + 1
+# Read current state; ask for VERSION; increment sprint (do not reuse literals)
+STATE=.cursor/skills/i18n-memsource/state.json
+VERSION=...   # ask / set from current OCP release — do not copy a stale example
+SPRINT=$(( $(jq -r '.sprint // 0' "$STATE") + 1 ))
 npm run memsource-upload -- -v "$VERSION" -s "$SPRINT"
 # capture PROJECT_ID from memsource project create output (.uid)
+# If upload fails after project create: save that PROJECT_ID into state.json
+# (or delete the orphan project in Phrase) before retrying — otherwise retry
+# creates a second project.
 ```
 
-After a successful upload, update `.cursor/skills/i18n-memsource/state.json`:
+After a successful upload, **merge** into `.cursor/skills/i18n-memsource/state.json`
+(append history; do not replace the whole file with a one-entry example):
 
-```json
-{
-  "version": "VERSION",
-  "sprint": 1,
-  "lastProjectId": "PROJECT_ID",
-  "memsourceProjectUrl": "https://cloud.memsource.com/web/project2/show/PROJECT_ID",
-  "history": [
-    {
-      "version": "VERSION",
-      "sprint": 1,
-      "projectId": "PROJECT_ID",
-      "date": "YYYY-MM-DD"
-    }
-  ]
-}
+```bash
+STATE=.cursor/skills/i18n-memsource/state.json
+PROJECT_ID=...   # from upload output
+TODAY=$(date +%F)
+jq --arg v "$VERSION" --argjson s "$SPRINT" --arg p "$PROJECT_ID" --arg d "$TODAY" '
+  .version = $v
+  | .sprint = $s
+  | .lastProjectId = $p
+  | .memsourceProjectUrl = ("https://cloud.memsource.com/web/project2/show/" + $p)
+  | .history = ((.history // []) + [{version:$v, sprint:$s, projectId:$p, date:$d}])
+' "$STATE" > "${STATE}.tmp" && mv "${STATE}.tmp" "$STATE"
 ```
 
 ---
@@ -166,9 +177,9 @@ After a successful upload, update `.cursor/skills/i18n-memsource/state.json`:
 
 `i18n-to-po` looks for `locales/zh-cn/` when building Chinese POs. If that path
 is missing, **all Chinese msgstr values are empty** and prior translations are
-not carried forward. Create `locales/zh-cn` → `zh` before export and remove it
-afterward (use a shell `trap` so cleanup runs even on failure). Download already
-remaps `zh-cn` → `zh`.
+not carried forward. Register an `EXIT` trap **before** `ln -sfn zh locales/zh-cn`,
+refuse to overwrite a non-symlink `locales/zh-cn`, and let the trap remove the
+symlink afterward (even on failure). Download already remaps `zh-cn` → `zh`.
 
 ---
 

--- a/.cursor/skills/i18n-memsource/USAGE.md
+++ b/.cursor/skills/i18n-memsource/USAGE.md
@@ -1,0 +1,213 @@
+# How to use the i18n Memsource skill (networking-console-plugin)
+
+This guide is for teammates who need to send new UI strings to Phrase/Memsource
+or pull finished translations back into the repo.
+
+You do **not** need to migrate the i18n toolchain. Keep using the existing
+`i18n-scripts/` + `i18next-parser` setup.
+
+---
+
+## What this skill does
+
+In Cursor, attach or invoke the **i18n-memsource** skill, then ask for one of:
+
+| You say… | Skill runs… |
+|----------|-------------|
+| "upload translations" / "memsource upload" | Extract keys → build POs (keeping existing translations) → upload to Phrase |
+| "download translations" / "memsource download" | Pull finished translations → convert to locale JSON → commit → optional PR |
+| "translation status" / "memsource status" | Show Phrase job status per language |
+
+State (last sprint, version, project ID) is stored in
+[`.cursor/skills/i18n-memsource/state.json`](./state.json).
+
+---
+
+## One-time setup (your machine)
+
+### 1. Clone and install
+
+```bash
+git clone https://github.com/openshift/networking-console-plugin.git
+cd networking-console-plugin
+npm install
+```
+
+### 2. Install Memsource CLI
+
+```bash
+DIRECTORY="${HOME}/git/memsource-cli-client/"
+mkdir -p "$DIRECTORY" && cd "$DIRECTORY"
+python3 -m venv --system-site-packages .memsource
+source .memsource/bin/activate
+pip install -U pip setuptools pbr memsource-cli
+```
+
+### 3. Create `~/.memsourcerc`
+
+```bash
+source ${HOME}/git/memsource-cli-client/.memsource/bin/activate
+export MEMSOURCE_URL="https://cloud.memsource.com/web"
+export MEMSOURCE_USERNAME=<your-username>
+export MEMSOURCE_PASSWORD="<your-password>"
+```
+
+The Cursor skill authenticates for you (captures `MEMSOURCE_TOKEN`). You should
+not need to run `memsource auth login` yourself when using the skill.
+
+Also install `jq` if missing: `brew install jq`.
+
+---
+
+## Upload flow (send strings for translation)
+
+### Using Cursor (recommended)
+
+1. Open this repo in Cursor.
+2. Attach the **i18n-memsource** skill (or ask: "upload translations using the i18n-memsource skill").
+3. When asked, provide the **OCP VERSION** (for example `4.20`). Sprint auto-increments from `state.json`.
+4. Review the locale diff and PO validation summary.
+5. Approve the upload when the summary looks correct.
+
+The skill will:
+
+1. Authenticate to Memsource
+2. Run `npm run i18n`
+3. Create a temporary `locales/zh-cn` → `zh` symlink (required — see below)
+4. Run `npm run export-pos` and validate POs
+5. Ask for your approval
+6. Run `npm run memsource-upload -- -v VERSION -s SPRINT`
+7. Clean up the symlink and update `state.json`
+8. Give you a draft email for the localization team
+
+### Manual upload (without Cursor)
+
+```bash
+cd networking-console-plugin
+
+# Auth (export token so npm scripts work)
+source ~/.memsourcerc
+export PATH="$(dirname "$(python3 -c "import shutil; print(shutil.which('memsource') or '')")"):$PATH"
+# If memsource is not on PATH, find it under ~/Library/Python
+export MEMSOURCE_TOKEN=$(memsource auth login \
+  --user-name "$MEMSOURCE_USERNAME" \
+  --password "$MEMSOURCE_PASSWORD" \
+  -f json \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['token'])")
+
+npm run i18n
+git diff --stat -- locales/   # review before continuing
+
+# CRITICAL: without this, Chinese existing translations are lost on upload
+ln -sfn zh locales/zh-cn
+
+rm -rf po-files
+npm run export-pos
+# spot-check po-files/*/
+
+npm run memsource-upload -- -v 4.20 -s 1
+
+rm -f locales/zh-cn
+rm -rf po-files locales/tmp
+```
+
+Record the Memsource project ID / URL from the upload output.
+
+---
+
+## Why the `zh-cn` symlink matters
+
+- Memsource language code: `zh-cn`
+- Repo locale directory: `locales/zh/`
+
+`i18n-to-po` looks for `locales/zh-cn/` when building Chinese POs. If that path
+is missing, **all Chinese msgstr values are empty** and prior translations are
+not carried forward. The skill creates `locales/zh-cn` → `zh` before export and
+removes it after upload. Download already remaps `zh-cn` → `zh`.
+
+---
+
+## How existing translations are preserved
+
+PO export does **not** upload English into every language blindly. For each language:
+
+1. Take English keys as the source of truth (`msgid`)
+2. Clear values
+3. Copy back any existing translation from `locales/<lang>/plugin__networking-console-plugin.json` into `msgstr`
+4. Leave new keys with empty `msgstr` for translators
+
+That is why you must run `npm run export-pos` (never hand-edit English-only POs).
+
+---
+
+## Download flow (pull finished translations)
+
+### Using Cursor
+
+1. Attach **i18n-memsource**.
+2. Ask: "download translations".
+3. Confirm the Memsource project ID (from `state.json` or paste a new one).
+4. Skill checks job status, ensures `locales/` is clean, runs download, shows the diff, and can open a PR.
+
+### Manual download
+
+```bash
+# Same auth as upload…
+
+# IMPORTANT: check root locales/ (the script checks the wrong paths)
+git status --short --untracked-files -- locales/
+# must be clean
+
+npm run memsource-download -- -p PROJECT_ID
+git diff HEAD~1 --stat -- locales/
+```
+
+Then push a branch / open a PR with the locale updates.
+
+---
+
+## Check status only
+
+Ask Cursor: "translation status"  
+or:
+
+```bash
+for lang in ja zh-cn ko fr es; do
+  memsource job list --project-id PROJECT_ID --target-lang "$lang" -f json -c uid,status,targetLang
+done
+```
+
+---
+
+## Common pitfalls
+
+| Pitfall | What happens | Fix |
+|---------|--------------|-----|
+| Skip `zh-cn` symlink on upload | Chinese translations wiped in the Phrase project | Always `ln -sfn zh locales/zh-cn` before export/upload |
+| Hand-build POs from English only | Existing ja/ko/fr/es/zh translations lost | Always use `npm run export-pos` |
+| Trust download script's git clean check | Uncommitted `locales/` changes get overwritten | Run `git status -- locales/` yourself |
+| Forget `MEMSOURCE_TOKEN` | `npm run memsource-*` fails auth | Export token after `memsource auth login` as shown above |
+| Upload without reviewing `npm run i18n` | Unexpected key churn in locale files | Always review `git diff -- locales/` first |
+
+---
+
+## After upload: notify localization
+
+Use the draft the skill prints, or:
+
+```
+Subject: [OCP VERSION] Translation Upload - networking-console-plugin Sprint SPRINT
+
+Hi Localization Team,
+
+New translation strings have been uploaded for networking-console-plugin
+(OCP VERSION, Sprint SPRINT).
+
+Memsource project: https://cloud.memsource.com/web/project2/show/PROJECT_ID
+
+Languages: ja, zh-cn, ko, fr, es
+
+Please review and translate at your convenience.
+
+Thanks
+```

--- a/.cursor/skills/i18n-memsource/USAGE.md
+++ b/.cursor/skills/i18n-memsource/USAGE.md
@@ -74,11 +74,12 @@ The skill will:
 1. Authenticate to Memsource
 2. Run `npm run i18n`
 3. Create a temporary `locales/zh-cn` → `zh` symlink (required — see below)
-4. Run `npm run export-pos` and validate POs
-5. Ask for your approval
-6. Run `npm run memsource-upload -- -v VERSION -s SPRINT`
-7. Clean up the symlink and update `state.json`
-8. Give you a draft email for the localization team
+4. Run `npm run export-pos` (builds POs, then clears English placeholders in msgstr)
+5. Validate POs (`translated` vs `needs_translation`; English leaks should be 0)
+6. Ask for your approval
+7. Run `npm run memsource-upload -- -v VERSION -s SPRINT`
+8. Clean up the symlink and update `state.json`
+9. Give you a draft email for the localization team
 
 ### Manual upload (without Cursor)
 
@@ -103,7 +104,8 @@ ln -sfn zh locales/zh-cn
 
 rm -rf po-files
 npm run export-pos
-# spot-check po-files/*/
+# export-pos also runs clear-english-msgstr.js so msgstr==msgid becomes empty
+# spot-check po-files/*/ — real translations kept, English placeholders empty
 
 npm run memsource-upload -- -v 4.20 -s 1
 
@@ -135,8 +137,19 @@ PO export does **not** upload English into every language blindly. For each lang
 2. Clear values
 3. Copy back any existing translation from `locales/<lang>/plugin__networking-console-plugin.json` into `msgstr`
 4. Leave new keys with empty `msgstr` for translators
+5. **Post-export clear:** if `msgstr` still equals `msgid` (English placeholder left by `i18next-parser`), clear it to empty so Phrase marks it as needing translation
+
+| Locale JSON value | msgstr uploaded to Phrase |
+|-------------------|---------------------------|
+| Real translation (e.g. Japanese) | Kept |
+| Empty | Empty (needs translation) |
+| English placeholder | Cleared to empty (needs translation) |
 
 That is why you must run `npm run export-pos` (never hand-edit English-only POs).
+
+### Optional future: migrate to `ocp-plugin-i18n-scripts`
+
+Forklift uses [`ocp-plugin-i18n-scripts`](https://github.com/avivtur/ocp-plugin-i18n-scripts), which filters English placeholders during PO generation. After that migration, `clear-english-msgstr.js` / the post-export clear step becomes **redundant** and can be removed.
 
 ---
 
@@ -185,6 +198,7 @@ done
 |---------|--------------|-----|
 | Skip `zh-cn` symlink on upload | Chinese translations wiped in the Phrase project | Always `ln -sfn zh locales/zh-cn` before export/upload |
 | Hand-build POs from English only | Existing ja/ko/fr/es/zh translations lost | Always use `npm run export-pos` |
+| Leave English in msgstr | Phrase may treat those strings as already translated | Use current `export-pos` (includes `clear-english-msgstr.js`) |
 | Trust download script's git clean check | Uncommitted `locales/` changes get overwritten | Run `git status -- locales/` yourself |
 | Forget `MEMSOURCE_TOKEN` | `npm run memsource-*` fails auth | Export token after `memsource auth login` as shown above |
 | Upload without reviewing `npm run i18n` | Unexpected key churn in locale files | Always review `git diff -- locales/` first |

--- a/.cursor/skills/i18n-memsource/USAGE.md
+++ b/.cursor/skills/i18n-memsource/USAGE.md
@@ -3,8 +3,13 @@
 This guide is for teammates who need to send new UI strings to Phrase/Memsource
 or pull finished translations back into the repo.
 
-You do **not** need to migrate the i18n toolchain. Keep using the existing
-`i18n-scripts/` + `i18next-parser` setup.
+This PR keeps the existing `i18n-scripts/` + `i18next-parser` setup as an
+**interim** workflow. A follow-up should migrate to
+[`i18next-cli`](https://github.com/i18next/i18next-cli) (and optionally
+[`ocp-plugin-i18n-scripts`](https://github.com/avivtur/ocp-plugin-i18n-scripts) /
+native Phrase [i18next JSON](https://support.phrase.com/hc/en-us/articles/7278275219612--JSON-i18next-i18nextV4-Strings)),
+which can drop most custom scripts including PO conversion and
+`clear-english-msgstr.js`.
 
 ---
 
@@ -43,7 +48,11 @@ source .memsource/bin/activate
 pip install -U pip setuptools pbr memsource-cli
 ```
 
-### 3. Create `~/.memsourcerc`
+Also install `jq` if missing: `brew install jq`.
+
+### 3. Memsource credentials (keep out of the agent)
+
+Create `~/.memsourcerc` for **your own shell only** (chmod 600):
 
 ```bash
 source ${HOME}/git/memsource-cli-client/.memsource/bin/activate
@@ -52,44 +61,46 @@ export MEMSOURCE_USERNAME=<your-username>
 export MEMSOURCE_PASSWORD="<your-password>"
 ```
 
-The Cursor skill authenticates for you (captures `MEMSOURCE_TOKEN`). You should
-not need to run `memsource auth login` yourself when using the skill.
+**Security:** Do **not** give Memsource username/password (or a long-lived token)
+to the Cursor agent. Treat Phrase like any other paid external service.
 
-Also install `jq` if missing: `brew install jq`.
+Recommended split:
+
+1. **You** authenticate in a local terminal and run `memsource-*` / upload-download
+   commands that need `MEMSOURCE_TOKEN`.
+2. The agent may help with extract/export/validation (`npm run i18n`,
+   `export-pos`, PO checks) and drafting notifications — without reading
+   `~/.memsourcerc`.
+
+If you temporarily export `MEMSOURCE_TOKEN` into a shell the agent uses, prefer
+a short-lived token and do not commit it or paste it into chat.
 
 ---
 
 ## Upload flow (send strings for translation)
 
-### Using Cursor (recommended)
+### Using Cursor (recommended for extract/validate)
 
 1. Open this repo in Cursor.
-2. Attach the **i18n-memsource** skill (or ask: "upload translations using the i18n-memsource skill").
-3. When asked, provide the **OCP VERSION** (for example `4.20`). Sprint auto-increments from `state.json`.
+2. Attach the **i18n-memsource** skill.
+3. Ask the agent to extract keys, create the `zh-cn` symlink, run `export-pos`,
+   and validate POs. Provide the **OCP VERSION** when asked (sprint auto-increments
+   from `state.json`).
 4. Review the locale diff and PO validation summary.
-5. Approve the upload when the summary looks correct.
+5. **You** run the Memsource upload in your own authenticated terminal (see manual
+   upload below), or export a short-lived `MEMSOURCE_TOKEN` yourself before asking
+   the agent to run `npm run memsource-upload`.
+6. Update `state.json` after a successful upload (or ask the agent to, using the
+   project ID from the upload output — not credentials).
 
-The skill will:
-
-1. Authenticate to Memsource
-2. Run `npm run i18n`
-3. Create a temporary `locales/zh-cn` → `zh` symlink (required — see below)
-4. Run `npm run export-pos` (builds POs, then clears English placeholders in msgstr)
-5. Validate POs (`translated` vs `needs_translation`; English leaks should be 0)
-6. Ask for your approval
-7. Run `npm run memsource-upload -- -v VERSION -s SPRINT`
-8. Clean up the symlink and update `state.json`
-9. Give you a draft email for the localization team
-
-### Manual upload (without Cursor)
+### Manual upload (authenticated shell)
 
 ```bash
 cd networking-console-plugin
 
-# Auth (export token so npm scripts work)
+# Auth in YOUR terminal only — do not paste password/token into Cursor chat
 source ~/.memsourcerc
 export PATH="$(dirname "$(python3 -c "import shutil; print(shutil.which('memsource') or '')")"):$PATH"
-# If memsource is not on PATH, find it under ~/Library/Python
 export MEMSOURCE_TOKEN=$(memsource auth login \
   --user-name "$MEMSOURCE_USERNAME" \
   --password "$MEMSOURCE_PASSWORD" \
@@ -101,19 +112,50 @@ git diff --stat -- locales/   # review before continuing
 
 # CRITICAL: without this, Chinese existing translations are lost on upload
 ln -sfn zh locales/zh-cn
+trap 'rm -f locales/zh-cn; rm -rf po-files locales/tmp' EXIT
 
 rm -rf po-files
 npm run export-pos
 # export-pos also runs clear-english-msgstr.js so msgstr==msgid becomes empty
-# spot-check po-files/*/ — real translations kept, English placeholders empty
+# validate: translated vs needs_translation; english_leaks_remaining should be 0
+for lang in ja zh-cn ko fr es; do
+  echo "=== $lang ==="
+  python3 -c "
+import re, glob, sys
+files = glob.glob(f'po-files/{sys.argv[1]}/*.po')
+content = ''.join(open(f).read() for f in files)
+entries = [(a,b) for a,b in re.findall(r'msgid \"(.*?)\"\nmsgstr \"(.*?)\"', content) if a]
+translated = sum(1 for a,b in entries if b and b != a)
+needs = sum(1 for a,b in entries if not b)
+leaks = sum(1 for a,b in entries if b and b == a)
+print(f'total={len(entries)} translated={translated} needs_translation={needs} english_leaks_remaining={leaks}')
+" "$lang"
+done
 
-npm run memsource-upload -- -v 4.20 -s 1
-
-rm -f locales/zh-cn
-rm -rf po-files locales/tmp
+VERSION=5.0.0   # set from release / ask user
+SPRINT=1        # previous state.sprint + 1
+npm run memsource-upload -- -v "$VERSION" -s "$SPRINT"
+# capture PROJECT_ID from memsource project create output (.uid)
 ```
 
-Record the Memsource project ID / URL from the upload output.
+After a successful upload, update `.cursor/skills/i18n-memsource/state.json`:
+
+```json
+{
+  "version": "VERSION",
+  "sprint": 1,
+  "lastProjectId": "PROJECT_ID",
+  "memsourceProjectUrl": "https://cloud.memsource.com/web/project2/show/PROJECT_ID",
+  "history": [
+    {
+      "version": "VERSION",
+      "sprint": 1,
+      "projectId": "PROJECT_ID",
+      "date": "YYYY-MM-DD"
+    }
+  ]
+}
+```
 
 ---
 
@@ -124,8 +166,9 @@ Record the Memsource project ID / URL from the upload output.
 
 `i18n-to-po` looks for `locales/zh-cn/` when building Chinese POs. If that path
 is missing, **all Chinese msgstr values are empty** and prior translations are
-not carried forward. The skill creates `locales/zh-cn` → `zh` before export and
-removes it after upload. Download already remaps `zh-cn` → `zh`.
+not carried forward. Create `locales/zh-cn` → `zh` before export and remove it
+afterward (use a shell `trap` so cleanup runs even on failure). Download already
+remaps `zh-cn` → `zh`.
 
 ---
 
@@ -147,9 +190,8 @@ PO export does **not** upload English into every language blindly. For each lang
 
 That is why you must run `npm run export-pos` (never hand-edit English-only POs).
 
-### Optional future: migrate to `ocp-plugin-i18n-scripts`
-
-Forklift uses [`ocp-plugin-i18n-scripts`](https://github.com/avivtur/ocp-plugin-i18n-scripts), which filters English placeholders during PO generation. After that migration, `clear-english-msgstr.js` / the post-export clear step becomes **redundant** and can be removed.
+With a modern Phrase + i18next JSON workflow, PO conversion and this clear step
+can go away (see migration note at the top).
 
 ---
 
@@ -160,18 +202,31 @@ Forklift uses [`ocp-plugin-i18n-scripts`](https://github.com/avivtur/ocp-plugin-
 1. Attach **i18n-memsource**.
 2. Ask: "download translations".
 3. Confirm the Memsource project ID (from `state.json` or paste a new one).
-4. Skill checks job status, ensures `locales/` is clean, runs download, shows the diff, and can open a PR.
+4. Skill checks job status, ensures `locales/` is clean, then you (or a shell with
+   your token) run download.
 
 ### Manual download
 
 ```bash
-# Same auth as upload…
+# Auth in YOUR terminal only (same as upload)
+
+PROJECT_ID=...   # from state.json
+
+# Require completed jobs before download
+for lang in ja zh-cn ko fr es; do
+  memsource job list \
+    --project-id "$PROJECT_ID" \
+    --target-lang "$lang" \
+    -f json \
+    -c uid,status,targetLang
+done
+# Proceed only when every job status is COMPLETED / DELIVERED (or equivalent)
 
 # IMPORTANT: check root locales/ (the script checks the wrong paths)
 git status --short --untracked-files -- locales/
 # must be clean
 
-npm run memsource-download -- -p PROJECT_ID
+npm run memsource-download -- -p "$PROJECT_ID"
 git diff HEAD~1 --stat -- locales/
 ```
 
@@ -200,7 +255,9 @@ done
 | Hand-build POs from English only | Existing ja/ko/fr/es/zh translations lost | Always use `npm run export-pos` |
 | Leave English in msgstr | Phrase may treat those strings as already translated | Use current `export-pos` (includes `clear-english-msgstr.js`) |
 | Trust download script's git clean check | Uncommitted `locales/` changes get overwritten | Run `git status -- locales/` yourself |
-| Forget `MEMSOURCE_TOKEN` | `npm run memsource-*` fails auth | Export token after `memsource auth login` as shown above |
+| Download before jobs complete | Incomplete locale overwrite | Check job status first |
+| Give Memsource password/token to the agent | Credential exposure | Authenticate only in your shell |
+| Forget to update `state.json` | Next download/status uses stale project ID | Update state after every upload |
 | Upload without reviewing `npm run i18n` | Unexpected key churn in locale files | Always review `git diff -- locales/` first |
 
 ---
@@ -209,7 +266,7 @@ done
 
 Use the draft the skill prints, or:
 
-```
+```text
 Subject: [OCP VERSION] Translation Upload - networking-console-plugin Sprint SPRINT
 
 Hi Localization Team,

--- a/.cursor/skills/i18n-memsource/state.json
+++ b/.cursor/skills/i18n-memsource/state.json
@@ -1,0 +1,7 @@
+{
+  "version": null,
+  "sprint": 0,
+  "lastProjectId": null,
+  "memsourceProjectUrl": null,
+  "history": []
+}

--- a/.cursor/skills/i18n-memsource/state.json
+++ b/.cursor/skills/i18n-memsource/state.json
@@ -1,7 +1,16 @@
 {
-  "version": null,
-  "sprint": 0,
-  "lastProjectId": null,
-  "memsourceProjectUrl": null,
-  "history": []
+  "version": "5.0.0",
+  "sprint": 1,
+  "lastProjectId": "IzpYNT0Aw1KA5Aj6zwcmZc",
+  "memsourceProjectUrl": "https://cloud.memsource.com/web/project2/show/IzpYNT0Aw1KA5Aj6zwcmZc",
+  "history": [
+    {
+      "version": "5.0.0",
+      "sprint": 1,
+      "projectId": "IzpYNT0Aw1KA5Aj6zwcmZc",
+      "branch": "chore/i18n-memsource-skill",
+      "uploadedAt": "2026-08-09T06:49:15Z",
+      "totalKeys": 497
+    }
+  ]
 }

--- a/i18n-scripts/clear-english-msgstr.js
+++ b/i18n-scripts/clear-english-msgstr.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Post-process PO files after export-pos:
+ * Clear msgstr when it equals msgid (English placeholder leaked from secondary locales).
+ *
+ * Phrase/Memsource treats empty msgstr as "needs translation". Leaving English in
+ * msgstr can make those strings look already translated.
+ *
+ * Real non-English translations (msgstr !== msgid) are left untouched.
+ *
+ * Note: ocp-plugin-i18n-scripts already filters English placeholders during PO
+ * generation, so this step is redundant after migrating to that package.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PO_ROOT = path.join(process.cwd(), 'po-files');
+
+function clearEnglishPlaceholders(content) {
+  let cleared = 0;
+  // Match single-line msgid/msgstr pairs produced by i18next-conv (foldLength: 0).
+  // Skip the header entry (empty msgid).
+  const updated = content.replace(
+    /msgid "((?:\\.|[^"\\])*)"\nmsgstr "((?:\\.|[^"\\])*)"/g,
+    (match, msgid, msgstr) => {
+      if (!msgid) {
+        return match;
+      }
+      if (msgstr && msgstr === msgid) {
+        cleared += 1;
+        return `msgid "${msgid}"\nmsgstr ""`;
+      }
+      return match;
+    },
+  );
+  return { cleared, updated };
+}
+
+function processPoFile(filePath) {
+  const original = fs.readFileSync(filePath, 'utf8');
+  const { cleared, updated } = clearEnglishPlaceholders(original);
+  if (cleared > 0) {
+    fs.writeFileSync(filePath, updated);
+  }
+  console.log(
+    `${path.relative(process.cwd(), filePath)}: cleared ${cleared} English placeholder(s)`,
+  );
+}
+
+function walk(dir) {
+  if (!fs.existsSync(dir)) {
+    console.error(`Missing ${dir}; run export-pos first`);
+    process.exit(1);
+  }
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full);
+    } else if (entry.name.endsWith('.po')) {
+      processPoFile(full);
+    }
+  }
+}
+
+walk(PO_ROOT);

--- a/i18n-scripts/clear-english-msgstr.js
+++ b/i18n-scripts/clear-english-msgstr.js
@@ -17,6 +17,16 @@ const path = require('path');
 
 const PO_ROOT = path.join(process.cwd(), 'po-files');
 
+function assertUnderPoRoot(candidatePath) {
+  const root = fs.realpathSync(PO_ROOT);
+  const resolved = fs.realpathSync(candidatePath);
+  const relative = path.relative(root, resolved);
+  if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`PO path escapes ${PO_ROOT}: ${candidatePath}`);
+  }
+  return resolved;
+}
+
 function clearEnglishPlaceholders(content) {
   let cleared = 0;
   // Match single-line msgid/msgstr pairs produced by i18next-conv (foldLength: 0).
@@ -53,12 +63,18 @@ function walk(dir) {
     console.error(`Missing ${dir}; run export-pos first`);
     process.exit(1);
   }
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const full = path.join(dir, entry.name);
+  const safeDir = assertUnderPoRoot(dir);
+  for (const entry of fs.readdirSync(safeDir, { withFileTypes: true })) {
+    // Skip symlinks so a crafted .po symlink cannot escape PO_ROOT.
+    if (entry.isSymbolicLink()) {
+      console.warn(`Skipping symlink under po-files: ${path.join(safeDir, entry.name)}`);
+      continue;
+    }
+    const full = path.resolve(safeDir, entry.name);
     if (entry.isDirectory()) {
-      walk(full);
+      walk(assertUnderPoRoot(full));
     } else if (entry.name.endsWith('.po')) {
-      processPoFile(full);
+      processPoFile(assertUnderPoRoot(full));
     }
   }
 }

--- a/i18n-scripts/clear-english-msgstr.js
+++ b/i18n-scripts/clear-english-msgstr.js
@@ -17,8 +17,20 @@ const path = require('path');
 
 const PO_ROOT = path.join(process.cwd(), 'po-files');
 
-function assertUnderPoRoot(candidatePath) {
-  const root = fs.realpathSync(PO_ROOT);
+function resolvePoRoot() {
+  if (!fs.existsSync(PO_ROOT)) {
+    console.error(`Missing ${PO_ROOT}; run export-pos first`);
+    process.exit(1);
+  }
+  // Reject a symlinked po-files/ so realpath cannot widen the trust boundary
+  // to an external directory.
+  if (fs.lstatSync(PO_ROOT).isSymbolicLink()) {
+    throw new Error(`Refusing to process symlinked PO_ROOT: ${PO_ROOT}`);
+  }
+  return fs.realpathSync(PO_ROOT);
+}
+
+function assertUnderPoRoot(candidatePath, root) {
   const resolved = fs.realpathSync(candidatePath);
   const relative = path.relative(root, resolved);
   if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
@@ -58,12 +70,8 @@ function processPoFile(filePath) {
   );
 }
 
-function walk(dir) {
-  if (!fs.existsSync(dir)) {
-    console.error(`Missing ${dir}; run export-pos first`);
-    process.exit(1);
-  }
-  const safeDir = assertUnderPoRoot(dir);
+function walk(dir, root) {
+  const safeDir = assertUnderPoRoot(dir, root);
   for (const entry of fs.readdirSync(safeDir, { withFileTypes: true })) {
     // Skip symlinks so a crafted .po symlink cannot escape PO_ROOT.
     if (entry.isSymbolicLink()) {
@@ -72,11 +80,12 @@ function walk(dir) {
     }
     const full = path.resolve(safeDir, entry.name);
     if (entry.isDirectory()) {
-      walk(assertUnderPoRoot(full));
-    } else if (entry.name.endsWith('.po')) {
-      processPoFile(assertUnderPoRoot(full));
+      walk(full, root);
+    } else if (entry.isFile() && entry.name.endsWith('.po')) {
+      processPoFile(assertUnderPoRoot(full, root));
     }
   }
 }
 
-walk(PO_ROOT);
+const poRoot = resolvePoRoot();
+walk(poRoot, poRoot);

--- a/i18n-scripts/export-pos.sh
+++ b/i18n-scripts/export-pos.sh
@@ -11,3 +11,8 @@ for f in locales/en/* ; do
   done
 done
 
+# Clear msgstr that still equal msgid (English placeholders from secondary locales).
+# Phrase treats empty msgstr as needing translation. Redundant after migrating to
+# ocp-plugin-i18n-scripts (that package filters English during PO generation).
+node ./i18n-scripts/clear-english-msgstr.js
+


### PR DESCRIPTION
## Summary
- Adds a repo-local Cursor skill at `.cursor/skills/i18n-memsource/` to automate Phrase/Memsource upload, download, and status checks
- Keeps the existing `i18n-scripts/` + `i18next-parser` toolchain (no forced migration)
- Includes [USAGE.md](.cursor/skills/i18n-memsource/USAGE.md) with a peer-facing walkthrough
- Clears English placeholders from PO `msgstr` after `export-pos` so Phrase sees them as needing translation


## Memsource project (Sprint 1 / OCP 5.0.0)

Uploaded PO files are in Phrase:

https://cloud.memsource.com/web/project2/show/IzpYNT0Aw1KA5Aj6zwcmZc

- Version: `5.0.0`
- Sprint: `1`
- Total keys: 497
- Also recorded in `.cursor/skills/i18n-memsource/state.json` for download/status

## Why
Peers need a reliable way to send missing translations to Phrase without losing existing locale work. This skill encodes the fragile steps that are easy to miss manually.

## Prerequisites to activate / use the skill

The skill only automates the workflow; each developer still needs local tooling and Phrase access:

1. **Cursor** with Agent skills enabled, and this repo checked out (including `.cursor/skills/i18n-memsource/`)
2. **Node.js** + `npm install` in the repo root
3. **`jq`** (`brew install jq` on macOS)
4. **Memsource / Phrase CLI** (`memsource-cli` via pip), e.g.:
   ```bash
   DIRECTORY="${HOME}/git/memsource-cli-client/"
   mkdir -p "$DIRECTORY" && cd "$DIRECTORY"
   python3 -m venv --system-site-packages .memsource
   source .memsource/bin/activate
   pip install -U pip setuptools pbr memsource-cli
   ```
5. **Memsource credentials** in `~/.memsourcerc` (Red Hat Phrase account with access to the localization template/projects):
   ```bash
   source ${HOME}/git/memsource-cli-client/.memsource/bin/activate
   export MEMSOURCE_URL="https://cloud.memsource.com/web"
   export MEMSOURCE_USERNAME=<your-username>
   export MEMSOURCE_PASSWORD="<your-password>"
   ```
   The skill captures `MEMSOURCE_TOKEN` from `memsource auth login` so `npm run memsource-*` works; peers do not need to run login by hand when using the skill.
6. **Permission** to create Memsource projects from template ID `zBOwr4BxYwEq7xlJ37c1F3` (same template this plugin already uses)

Without (4)–(6), upload/download/status will fail at auth or project creation. Extract/export-only steps (`npm run i18n`, `export-pos`) only need (2).

Full one-time setup: [`.cursor/skills/i18n-memsource/USAGE.md`](.cursor/skills/i18n-memsource/USAGE.md)

## Critical nuances documented and automated
1. **`zh-cn` → `zh` symlink** before `export-pos` — without it, Chinese carry-forward is empty on upload
2. **PO consolidation** — English keys + merge of existing `locales/<lang>/` translations (never hand-build English-only POs)
3. **Clear English placeholders after export** — `i18n-scripts/clear-english-msgstr.js` empties `msgstr` when it equals `msgid` (leaked English from `i18next-parser` defaults). Empty locale values already produce empty `msgstr` (correct). Real non-English translations are kept.
4. **Download clean check** — verify root `locales/` (the script checks `public/locales`, which is wrong here)

## How peers use it
1. Open this repo in Cursor
2. Attach / invoke the **i18n-memsource** skill
3. Say e.g. `upload translations` and provide the OCP VERSION when asked
4. Review the locale diff + PO validation (`translated` vs `needs_translation`; English leaks should be 0), then approve the Memsource upload

## Follow-up suggestion: migrate to `ocp-plugin-i18n-scripts`
This PR deliberately keeps the local `i18n-scripts/` setup. A worthwhile follow-up is migrating to [`ocp-plugin-i18n-scripts`](https://github.com/avivtur/ocp-plugin-i18n-scripts) (as Forklift does).

That package already filters English placeholders during PO generation (`translatedValue !== englishValue && translatedValue !== key`). After such a migration:
- **`clear-english-msgstr.js` / the post-`export-pos` clear step becomes redundant** and should be removed
- Language aliases (`zh-cn` → `zh`) and other upload quirks are handled by config instead of symlinks/workarounds

This PR’s clear step is the minimal fix while staying on the old scripts.

## Demo 

https://github.com/user-attachments/assets/2ba9d1c5-14d9-4ac9-a720-037f0a82088c



## Test plan
- [x] Open `.cursor/skills/i18n-memsource/USAGE.md` and confirm the peer steps / prerequisites are clear
- [x] With Memsource credentials configured, confirm `memsource auth whoami` works
- [x] `npm install` → `ln -sfn zh locales/zh-cn` → `npm run export-pos` → confirm console reports cleared English placeholders
- [x] Validate POs: real translations kept, `msgstr == msgid` count is 0, former English placeholders are empty
- [x] Confirm Chinese PO still has non-empty msgstr for previously translated keys when the symlink is present
- [x] Optional: full upload only when intentionally sending a sprint to localization


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added documented workflows for managing translations through Memsource/Phrase, including upload, download, authentication, status checks, and approval steps.
  * Added guidance for handling Chinese locale files and preserving translation placeholders.
  * Added translation workflow state tracking for sprint progress.

* **Bug Fixes**
  * PO export now removes untranslated entries that duplicate English source text.
  * Added safeguards to prevent processing paths outside the designated translation directory or through symlinks.

* **Documentation**
  * Added setup, usage, troubleshooting, cleanup, and localization-team handoff guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->