### PR TITLE
OCPNETUI-63: Support custom TLS settings in the Helm charts

### DIFF
--- a/charts/openshift-console-plugin/templates/configmap.yaml
+++ b/charts/openshift-console-plugin/templates/configmap.yaml
@@ -19,6 +19,15 @@ data:
         listen              [::]:{{ .Values.plugin.port }} ssl;
         ssl_certificate     /var/cert/tls.crt;
         ssl_certificate_key /var/cert/tls.key;
+        {{- if .Values.tls.protocols }}
+        ssl_protocols       {{ .Values.tls.protocols }};
+        {{- end }}
+        {{- if .Values.tls.ciphers }}
+        ssl_ciphers         {{ .Values.tls.ciphers }};
+        {{- end }}
+        {{- if .Values.tls.preferServerCiphers }}
+        ssl_prefer_server_ciphers {{ .Values.tls.preferServerCiphers }};
+        {{- end }}
         root                /usr/share/nginx/html;
       }
     }

--- a/charts/openshift-console-plugin/values.yaml
+++ b/charts/openshift-console-plugin/values.yaml
@@ -1,11 +1,15 @@
 ---
 plugin:
-  name: ""
-  description: ""
-  image: ""
+  name: ''
+  description: ''
+  image: ''
   imagePullPolicy: IfNotPresent
   replicas: 2
   port: 9443
+  tls:
+    protocols: 'TLSv1.2 TLSv1.3'
+    ciphers: 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305'
+    preferServerCiphers: 'on'
   securityContext:
     enabled: true
   podSecurityContext:
@@ -24,19 +28,19 @@ plugin:
       cpu: 10m
       memory: 50Mi
   basePath: /
-  certificateSecretName: ""
+  certificateSecretName: ''
   serviceAccount:
     create: true
     annotations: {}
-    name: ""
+    name: ''
   patcherServiceAccount:
     create: true
     annotations: {}
-    name: ""
+    name: ''
   jobs:
     patchConsoles:
       enabled: true
-      image: "registry.redhat.io/openshift4/ose-tools-rhel8@sha256:e44074f21e0cca6464e50cb6ff934747e0bd11162ea01d522433a1a1ae116103"
+      image: 'registry.redhat.io/openshift4/ose-tools-rhel8@sha256:e44074f21e0cca6464e50cb6ff934747e0bd11162ea01d522433a1a1ae116103'
       podSecurityContext:
         enabled: true
         runAsNonRoot: true


### PR DESCRIPTION
Provide default values based on tlsref.org intermediate config.

Reference-Url: https://configurator.tlsref.org/#server=nginx&version=1.27.3&config=intermediate&openssl=4.0.1&hsts&guideline=6.0
Reference-Url: https://github.com/openshift/cluster-network-operator/pull/3043

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable TLS protocol versions and cipher suites for the plugin.
  * Added support for prioritizing server-selected ciphers.
  * TLS settings are applied only when configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->